### PR TITLE
adds qwen3-4b fp16 and awq to working models

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,16 +19,18 @@ This setup is **highly experimental** on ROCm/Strix Halo. Some models work; **ma
 
 | Model (Hugging Face)               | Params / Quant |               Status | Required flags (if any)                              | Notes / Errors                                                                                       |
 | ---------------------------------- | -------------- | -------------------: | ---------------------------------------------------- | ---------------------------------------------------------------------------------------------------- |
-| `Qwen/Qwen2.5-7B-Instruct`         | 7B FP16        |              ✅ Works | (recommended) `--dtype float16`                      | Good baseline; simple serve works.                                                                   |
-| `meta-llama/Llama-2-7b-chat-hf`    | 7B FP16        |              ✅ Works | (recommended) `--dtype float16`                      | Stable.                                                                                              |
-| `Qwen/Qwen3-30B-A3B-Instruct-2507` | 30B (A3B) FP16 |              ✅ Works | (recommended) `--dtype float16`                      |  |
-| `Google/Gemma3-27B-Instruct`       | 27B FP16       |              ✅ Works | (recommended) `--dtype float16`                      | Slow         |
-| `Google/Gemma3-12B-Instruct`       | 12B FP16       |              ✅ Works | (recommended) `--dtype float16`                      |          |
-| `Google/Gemma3-4B-Instruct`        |4B FP16       |              ✅ Works | (recommended) `--dtype float16`                      |          |
-| `Qwen/Qwen3-14B-AWQ`               | 14B AWQ        | ✅ Works (with flags) | `--quantization awq --dtype float16 --enforce-eager` | On ROCm, eager avoids missing `awq_dequantize` during compile; vLLM auto‑sets `VLLM_USE_TRITON_AWQ`. |
-| `openai/gpt-oss-20b`               | 20B MXFP4      |              ❌ Fails | —                                                    | `ModuleNotFoundError: triton_kernels.matmul_ogs` (MXFP4 path not available in this image).           |
-| `zai-org/GLM-4.5-Air-FP8`          | FP8            |              ❌ Fails | —                                                    | `ValueError: type fp8e4nv not supported (only 'fp8e5')`.                                             |
-| `cpatonn/GLM-4.5-Air-AWQ-4bit`     | AWQ-4bit (MoE) |              ❌ Fails | —                                                    | Missing custom op: `torch.ops._C.gptq_marlin_repack` (Marlin kernels).                               |
+| `Qwen/Qwen2.5-7B-Instruct`          | 7B FP16        |              ✅ Works | (recommended) `--dtype float16`                      | Good baseline; simple serve works.                                                                   |
+| `meta-llama/Llama-2-7b-chat-hf`     | 7B FP16        |              ✅ Works | (recommended) `--dtype float16`                      | Stable.                                                                                              |
+| `Qwen/Qwen3-30B-A3B-Instruct-2507`  | 30B (A3B) FP16 |              ✅ Works | (recommended) `--dtype float16`                      |  |
+| `Qwen/Qwen3-4B-Instruct-2507`       | 4B FP16        |              ✅ Works | (recommended) `--dtype float16`                      |  |
+| `Google/Gemma3-27B-Instruct`        | 27B FP16       |              ✅ Works | (recommended) `--dtype float16`                      | Slow         |
+| `Google/Gemma3-12B-Instruct`        | 12B FP16       |              ✅ Works | (recommended) `--dtype float16`                      |          |
+| `Google/Gemma3-4B-Instruct`         | 4B FP16        |              ✅ Works | (recommended) `--dtype float16`                      |          |
+| `Qwen/Qwen3-14B-AWQ`                | 14B AWQ        | ✅ Works (with flags) | `--quantization awq --dtype float16 --enforce-eager` | On ROCm, eager avoids missing `awq_dequantize` during compile; vLLM auto‑sets `VLLM_USE_TRITON_AWQ`. |
+| `Eslzzyl/Qwen3-4B-Instruct-2507-AWQ`| 4B AWQ         | ✅ Works (with flags) | `--quantization awq --dtype float16 --enforce-eager` | On ROCm, eager avoids missing `awq_dequantize` during compile; vLLM auto‑sets `VLLM_USE_TRITON_AWQ`. |
+| `openai/gpt-oss-20b`                | 20B MXFP4      |              ❌ Fails | —                                                    | `ModuleNotFoundError: triton_kernels.matmul_ogs` (MXFP4 path not available in this image).           |
+| `zai-org/GLM-4.5-Air-FP8`           | FP8            |              ❌ Fails | —                                                    | `ValueError: type fp8e4nv not supported (only 'fp8e5')`.                                             |
+| `cpatonn/GLM-4.5-Air-AWQ-4bit`      | AWQ-4bit (MoE) |              ❌ Fails | —                                                    | Missing custom op: `torch.ops._C.gptq_marlin_repack` (Marlin kernels).                               |
 
 > If you get a model to work, please PR a new row with: **model name**, **exact flags**, vLLM version, `torch` & `triton` versions, and a note on **gfx1151** driver/kernel stack.
 


### PR DESCRIPTION
Command run: `vllm serve Qwen/Qwen3-4B-Instruct-2507 --host 0.0.0.0 --port 8000 --download-dir /home/matt/vllm-models --served-model-name qwen3-4b --gpu-memory-utilization 0.25 --max-model-len 131000`

and for awq:

`VLLM_USE_TRITON_AWQ=1 vllm serve Eslzzyl/Qwen3-4B-Instruct-2507-AWQ --host 0.0.0.0 --port 8000 --download-dir
home/matt/vllm-models --served-model-name qwen3-4b --gpu-memory-utilization 0.25 --max-model-len 131000 --quantization awq --dtype float16 --enforce-eager`

Successful log:

```
INFO 10-26 21:46:45 [__init__.py:245] Automatically detected platform rocm.
WARNING 10-26 21:46:45 [rocm.py:29] Failed to import from amdsmi with ModuleNotFoundError("No module named 'amdsmi'")
(APIServer pid=3856094) INFO 10-26 21:46:48 [api_server.py:1882] vLLM API server version 0.1.dev1+g6997a25ac.d20250904
(APIServer pid=3856094) INFO 10-26 21:46:48 [utils.py:328] non-default args: {'model_tag': 'Qwen/Qwen3-4B-Instruct-2507', 'host': '0.0.0.0', 'model': 'Qwen/Qwen3-4B-Instruct-2507', 'max_model_len': 131000, 'served_model_name': ['qwen3-4b'], 'download_dir': '/home/matt/vllm-models', 'gpu_memory_utilization': 0.25}
(APIServer pid=3856094) INFO 10-26 21:46:53 [__init__.py:745] Resolved architecture: Qwen3ForCausalLM
(APIServer pid=3856094) `torch_dtype` is deprecated! Use `dtype` instead!
(APIServer pid=3856094) INFO 10-26 21:46:53 [__init__.py:1778] Using max model len 131000
(APIServer pid=3856094) INFO 10-26 21:46:54 [scheduler.py:222] Chunked prefill is enabled with max_num_batched_tokens=8192.
INFO 10-26 21:46:56 [__init__.py:245] Automatically detected platform rocm.
WARNING 10-26 21:46:56 [rocm.py:29] Failed to import from amdsmi with ModuleNotFoundError("No module named 'amdsmi'")
(EngineCore_0 pid=3856547) INFO 10-26 21:46:58 [core.py:648] Waiting for init message from front-end.
(EngineCore_0 pid=3856547) INFO 10-26 21:46:58 [core.py:75] Initializing a V1 LLM engine (v0.1.dev1+g6997a25ac.d20250904) with config: model='Qwen/Qwen3-4B-Instruct-2507', speculative_config=None, tokenizer='Qwen/Qwen3-4B-Instruct-2507', skip_tokenizer_init=False, tokenizer_mode=auto, revision=None, override_neuron_config={}, tokenizer_revision=None, trust_remote_code=False, dtype=torch.bfloat16, max_seq_len=131000, download_dir='/home/matt/vllm-models', load_format=auto, tensor_parallel_size=1, pipeline_parallel_size=1, disable_custom_all_reduce=True, quantization=None, enforce_eager=False, kv_cache_dtype=auto, device_config=cuda, decoding_config=DecodingConfig(backend='auto', disable_fallback=False, disable_any_whitespace=False, disable_additional_properties=False, reasoning_backend=''), observability_config=ObservabilityConfig(show_hidden_metrics_for_version=None, otlp_traces_endpoint=None, collect_detailed_traces=None), seed=0, served_model_name=qwen3-4b, enable_prefix_caching=True, chunked_prefill_enabled=True, use_async_output_proc=True, pooler_config=None, compilation_config={"level":3,"debug_dump_path":"","cache_dir":"","backend":"","custom_ops":[],"splitting_ops":["vllm.unified_attention","vllm.unified_attention_with_output","vllm.mamba_mixer2","vllm.mamba_mixer","vllm.short_conv","vllm.linear_attention"],"use_inductor":true,"compile_sizes":[],"inductor_compile_config":{"enable_auto_functionalized_v2":false},"inductor_passes":{},"cudagraph_mode":1,"use_cudagraph":true,"cudagraph_num_of_warmups":1,"cudagraph_capture_sizes":[512,504,496,488,480,472,464,456,448,440,432,424,416,408,400,392,384,376,368,360,352,344,336,328,320,312,304,296,288,280,272,264,256,248,240,232,224,216,208,200,192,184,176,168,160,152,144,136,128,120,112,104,96,88,80,72,64,56,48,40,32,24,16,8,4,2,1],"cudagraph_copy_inputs":false,"full_cuda_graph":false,"pass_config":{},"max_capture_size":512,"local_cache_dir":null}
(EngineCore_0 pid=3856547) WARNING 10-26 21:46:59 [parallel_state.py:1000] Distributed backend nccl is not available; falling back to gloo.
[W1026 21:47:03.849672180 ProcessGroupGloo.cpp:516] Warning: Unable to resolve hostname to a (local) address. Using the loopback address as fallback. Manually set the network interface to bind to with GLOO_SOCKET_IFNAME. (function operator())
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
(EngineCore_0 pid=3856547) INFO 10-26 21:47:43 [parallel_state.py:1134] rank 0 in world size 1 is assigned as DP rank 0, PP rank 0, TP rank 0, EP rank 0
(EngineCore_0 pid=3856547) INFO 10-26 21:47:43 [gpu_model_runner.py:1921] Starting to load model Qwen/Qwen3-4B-Instruct-2507...
(EngineCore_0 pid=3856547) INFO 10-26 21:47:43 [gpu_model_runner.py:1953] Loading model from scratch...
(EngineCore_0 pid=3856547) INFO 10-26 21:47:43 [rocm.py:245] Using Triton Attention backend on V1 engine.
(EngineCore_0 pid=3856547) INFO 10-26 21:47:43 [triton_attn.py:257] Using vllm unified attention for TritonAttentionImpl
(EngineCore_0 pid=3856547) INFO 10-26 21:47:44 [weight_utils.py:304] Using model weights format ['*.safetensors']
Loading safetensors checkpoint shards:   0% Completed | 0/3 [00:00<?, ?it/s]
Loading safetensors checkpoint shards:  67% Completed | 2/3 [00:00<00:00,  3.58it/s]
Loading safetensors checkpoint shards: 100% Completed | 3/3 [00:01<00:00,  2.32it/s]
Loading safetensors checkpoint shards: 100% Completed | 3/3 [00:01<00:00,  2.50it/s]
(EngineCore_0 pid=3856547) 
(EngineCore_0 pid=3856547) INFO 10-26 21:47:45 [default_loader.py:267] Loading weights took 1.27 seconds
(EngineCore_0 pid=3856547) INFO 10-26 21:47:46 [gpu_model_runner.py:1975] Model loading took 7.6785 GiB and 2.195456 seconds
(EngineCore_0 pid=3856547) INFO 10-26 21:47:50 [backends.py:538] Using cache directory: /home/matt/.cache/vllm/torch_compile_cache/f78161e411/rank_0_0/backbone for vLLM's torch.compile
(EngineCore_0 pid=3856547) INFO 10-26 21:47:50 [backends.py:549] Dynamo bytecode transform time: 3.70 s
(EngineCore_0 pid=3856547) INFO 10-26 21:47:56 [backends.py:161] Directly load the compiled graph(s) for dynamic shape from the cache, took 5.920 s
(EngineCore_0 pid=3856547) INFO 10-26 21:47:59 [monitor.py:34] torch.compile takes 3.70 s in total
(EngineCore_0 pid=3856547) INFO 10-26 21:48:00 [gpu_worker.py:276] Available KV cache memory: 18.38 GiB
(EngineCore_0 pid=3856547) INFO 10-26 21:48:00 [kv_cache_utils.py:850] GPU KV cache size: 133,808 tokens
(EngineCore_0 pid=3856547) INFO 10-26 21:48:00 [kv_cache_utils.py:854] Maximum concurrency for 131,000 tokens per request: 1.02x
Capturing CUDA graphs (mixed prefill-decode, PIECEWISE): 100%|██████████████████████████████████████████████| 67/67 [00:07<00:00,  8.97it/s]
(EngineCore_0 pid=3856547) INFO 10-26 21:48:09 [gpu_model_runner.py:2676] Graph capturing finished in 8 secs, took 0.50 GiB
(EngineCore_0 pid=3856547) INFO 10-26 21:48:10 [core.py:217] init engine (profile, create kv cache, warmup model) took 24.13 seconds
(APIServer pid=3856094) INFO 10-26 21:48:11 [loggers.py:142] Engine 000: vllm cache_config_info with initialization after num_gpu_blocks is: 8363
(APIServer pid=3856094) INFO 10-26 21:48:11 [async_llm.py:166] Torch profiler disabled. AsyncLLM CPU traces will not be collected.
(APIServer pid=3856094) INFO 10-26 21:48:11 [api_server.py:1680] Supported_tasks: ['generate']
(APIServer pid=3856094) WARNING 10-26 21:48:11 [__init__.py:1678] Default sampling parameters have been overridden by the model's Hugging Face generation config recommended from the model creator. If this is not intended, please relaunch vLLM instance with `--generation-config vllm`.
(APIServer pid=3856094) INFO 10-26 21:48:11 [serving_responses.py:126] Using default chat sampling params from model: {'temperature': 0.7, 'top_k': 20, 'top_p': 0.8}
(APIServer pid=3856094) INFO 10-26 21:48:11 [serving_chat.py:137] Using default chat sampling params from model: {'temperature': 0.7, 'top_k': 20, 'top_p': 0.8}
(APIServer pid=3856094) INFO 10-26 21:48:11 [serving_completion.py:79] Using default completion sampling params from model: {'temperature': 0.7, 'top_k': 20, 'top_p': 0.8}
(APIServer pid=3856094) INFO 10-26 21:48:11 [api_server.py:1957] Starting vLLM API server 0 on http://0.0.0.0:8000
(APIServer pid=3856094) INFO 10-26 21:48:11 [launcher.py:36] Available routes are:
(APIServer pid=3856094) INFO 10-26 21:48:11 [launcher.py:44] Route: /openapi.json, Methods: GET, HEAD
(APIServer pid=3856094) INFO 10-26 21:48:11 [launcher.py:44] Route: /docs, Methods: GET, HEAD
(APIServer pid=3856094) INFO 10-26 21:48:11 [launcher.py:44] Route: /docs/oauth2-redirect, Methods: GET, HEAD
(APIServer pid=3856094) INFO 10-26 21:48:11 [launcher.py:44] Route: /redoc, Methods: GET, HEAD
(APIServer pid=3856094) INFO 10-26 21:48:11 [launcher.py:44] Route: /health, Methods: GET
(APIServer pid=3856094) INFO 10-26 21:48:11 [launcher.py:44] Route: /load, Methods: GET
(APIServer pid=3856094) INFO 10-26 21:48:11 [launcher.py:44] Route: /ping, Methods: POST
(APIServer pid=3856094) INFO 10-26 21:48:11 [launcher.py:44] Route: /ping, Methods: GET
(APIServer pid=3856094) INFO 10-26 21:48:11 [launcher.py:44] Route: /tokenize, Methods: POST
(APIServer pid=3856094) INFO 10-26 21:48:11 [launcher.py:44] Route: /detokenize, Methods: POST
(APIServer pid=3856094) INFO 10-26 21:48:11 [launcher.py:44] Route: /v1/models, Methods: GET
(APIServer pid=3856094) INFO 10-26 21:48:11 [launcher.py:44] Route: /version, Methods: GET
(APIServer pid=3856094) INFO 10-26 21:48:11 [launcher.py:44] Route: /v1/responses, Methods: POST
(APIServer pid=3856094) INFO 10-26 21:48:11 [launcher.py:44] Route: /v1/responses/{response_id}, Methods: GET
(APIServer pid=3856094) INFO 10-26 21:48:11 [launcher.py:44] Route: /v1/responses/{response_id}/cancel, Methods: POST
(APIServer pid=3856094) INFO 10-26 21:48:11 [launcher.py:44] Route: /v1/chat/completions, Methods: POST
(APIServer pid=3856094) INFO 10-26 21:48:11 [launcher.py:44] Route: /v1/completions, Methods: POST
(APIServer pid=3856094) INFO 10-26 21:48:11 [launcher.py:44] Route: /v1/embeddings, Methods: POST
(APIServer pid=3856094) INFO 10-26 21:48:11 [launcher.py:44] Route: /pooling, Methods: POST
(APIServer pid=3856094) INFO 10-26 21:48:11 [launcher.py:44] Route: /classify, Methods: POST
(APIServer pid=3856094) INFO 10-26 21:48:11 [launcher.py:44] Route: /score, Methods: POST
(APIServer pid=3856094) INFO 10-26 21:48:11 [launcher.py:44] Route: /v1/score, Methods: POST
(APIServer pid=3856094) INFO 10-26 21:48:11 [launcher.py:44] Route: /v1/audio/transcriptions, Methods: POST
(APIServer pid=3856094) INFO 10-26 21:48:11 [launcher.py:44] Route: /v1/audio/translations, Methods: POST
(APIServer pid=3856094) INFO 10-26 21:48:11 [launcher.py:44] Route: /rerank, Methods: POST
(APIServer pid=3856094) INFO 10-26 21:48:11 [launcher.py:44] Route: /v1/rerank, Methods: POST
(APIServer pid=3856094) INFO 10-26 21:48:11 [launcher.py:44] Route: /v2/rerank, Methods: POST
(APIServer pid=3856094) INFO 10-26 21:48:11 [launcher.py:44] Route: /scale_elastic_ep, Methods: POST
(APIServer pid=3856094) INFO 10-26 21:48:11 [launcher.py:44] Route: /is_scaling_elastic_ep, Methods: POST
(APIServer pid=3856094) INFO 10-26 21:48:11 [launcher.py:44] Route: /invocations, Methods: POST
(APIServer pid=3856094) INFO 10-26 21:48:11 [launcher.py:44] Route: /metrics, Methods: GET
(APIServer pid=3856094) INFO:     Started server process [3856094]
(APIServer pid=3856094) INFO:     Waiting for application startup.
(APIServer pid=3856094) INFO:     Application startup complete.
(APIServer pid=3856094) INFO:     127.0.0.1:38078 - "POST /chat/completions HTTP/1.1" 404 Not Found
(APIServer pid=3856094) INFO:     127.0.0.1:56650 - "GET /v1/models HTTP/1.1" 200 OK
(APIServer pid=3856094) INFO:     127.0.0.1:46356 - "POST /chat/completions HTTP/1.1" 404 Not Found
(APIServer pid=3856094) INFO 10-26 21:49:15 [chat_utils.py:507] Detected the chat template content format to be 'string'. You can set `--chat-template-content-format` to override this.
(APIServer pid=3856094) INFO:     127.0.0.1:52292 - "POST /v1/chat/completions HTTP/1.1" 200 OK
(APIServer pid=3856094) INFO 10-26 21:49:21 [loggers.py:123] Engine 000: Avg prompt throughput: 0.9 tokens/s, Avg generation throughput: 1.3 tokens/s, Running: 0 reqs, Waiting: 0 reqs, GPU KV cache usage: 0.0%, Prefix cache hit rate: 0.0%
(APIServer pid=3856094) INFO:     127.0.0.1:41300 - "POST /v1/chat/completions HTTP/1.1" 200 OK
(APIServer pid=3856094) INFO 10-26 21:49:31 [loggers.py:123] Engine 000: Avg prompt throughput: 1.5 tokens/s, Avg generation throughput: 8.5 tokens/s, Running: 1 reqs, Waiting: 0 reqs, GPU KV cache usage: 0.1%, Prefix cache hit rate: 0.0%
(APIServer pid=3856094) INFO 10-26 21:49:41 [loggers.py:123] Engine 000: Avg prompt throughput: 0.0 tokens/s, Avg generation throughput: 16.7 tokens/s, Running: 1 reqs, Waiting: 0 reqs, GPU KV cache usage: 0.2%, Prefix cache hit rate: 0.0%
(APIServer pid=3856094) INFO 10-26 21:49:51 [loggers.py:123] Engine 000: Avg prompt throughput: 0.0 tokens/s, Avg generation throughput: 16.6 tokens/s, Running: 1 reqs, Waiting: 0 reqs, GPU KV cache usage: 0.3%, Prefix cache hit rate: 0.0%
^C(APIServer pid=3856094) INFO 10-26 21:49:58 [launcher.py:101] Shutting down FastAPI HTTP server.
(APIServer pid=3856094) INFO:     Shutting down
(APIServer pid=3856094) INFO:     Waiting for application shutdown.
(APIServer pid=3856094) INFO:     Application shutdown complete.
```

and for awq:

```
INFO 10-26 21:59:21 [__init__.py:245] Automatically detected platform rocm.
WARNING 10-26 21:59:21 [rocm.py:29] Failed to import from amdsmi with ModuleNotFoundError("No module named 'amdsmi'")
(APIServer pid=3873368) INFO 10-26 21:59:23 [api_server.py:1882] vLLM API server version 0.1.dev1+g6997a25ac.d20250904
(APIServer pid=3873368) INFO 10-26 21:59:23 [utils.py:328] non-default args: {'model_tag': 'Eslzzyl/Qwen3-4B-Instruct-2507-AWQ', 'host': '0.0.0.0', 'model': 'Eslzzyl/Qwen3-4B-Instruct-2507-AWQ', 'dtype': 'float16', 'max_model_len': 131000, 'quantization': 'awq', 'enforce_eager': True, 'served_model_name': ['qwen3-4b'], 'download_dir': '/home/matt/vllm-models', 'gpu_memory_utilization': 0.25}
(APIServer pid=3873368) INFO 10-26 21:59:28 [__init__.py:745] Resolved architecture: Qwen3ForCausalLM
(APIServer pid=3873368) `torch_dtype` is deprecated! Use `dtype` instead!
(APIServer pid=3873368) WARNING 10-26 21:59:28 [__init__.py:2892] Casting torch.bfloat16 to torch.float16.
(APIServer pid=3873368) INFO 10-26 21:59:28 [__init__.py:1778] Using max model len 131000
(APIServer pid=3873368) WARNING 10-26 21:59:28 [_ipex_ops.py:16] Import error msg: No module named 'intel_extension_for_pytorch'
(APIServer pid=3873368) WARNING 10-26 21:59:28 [__init__.py:1219] awq quantization is not fully optimized yet. The speed can be slower than non-quantized models.
(APIServer pid=3873368) INFO 10-26 21:59:29 [scheduler.py:222] Chunked prefill is enabled with max_num_batched_tokens=8192.
(APIServer pid=3873368) INFO 10-26 21:59:29 [__init__.py:3643] Cudagraph is disabled under eager mode
INFO 10-26 21:59:31 [__init__.py:245] Automatically detected platform rocm.
WARNING 10-26 21:59:31 [rocm.py:29] Failed to import from amdsmi with ModuleNotFoundError("No module named 'amdsmi'")
(EngineCore_0 pid=3873791) INFO 10-26 21:59:34 [core.py:648] Waiting for init message from front-end.
(EngineCore_0 pid=3873791) INFO 10-26 21:59:34 [core.py:75] Initializing a V1 LLM engine (v0.1.dev1+g6997a25ac.d20250904) with config: model='Eslzzyl/Qwen3-4B-Instruct-2507-AWQ', speculative_config=None, tokenizer='Eslzzyl/Qwen3-4B-Instruct-2507-AWQ', skip_tokenizer_init=False, tokenizer_mode=auto, revision=None, override_neuron_config={}, tokenizer_revision=None, trust_remote_code=False, dtype=torch.float16, max_seq_len=131000, download_dir='/home/matt/vllm-models', load_format=auto, tensor_parallel_size=1, pipeline_parallel_size=1, disable_custom_all_reduce=True, quantization=awq, enforce_eager=True, kv_cache_dtype=auto, device_config=cuda, decoding_config=DecodingConfig(backend='auto', disable_fallback=False, disable_any_whitespace=False, disable_additional_properties=False, reasoning_backend=''), observability_config=ObservabilityConfig(show_hidden_metrics_for_version=None, otlp_traces_endpoint=None, collect_detailed_traces=None), seed=0, served_model_name=qwen3-4b, enable_prefix_caching=True, chunked_prefill_enabled=True, use_async_output_proc=True, pooler_config=None, compilation_config={"level":0,"debug_dump_path":"","cache_dir":"","backend":"","custom_ops":[],"splitting_ops":null,"use_inductor":true,"compile_sizes":[],"inductor_compile_config":{"enable_auto_functionalized_v2":false},"inductor_passes":{},"cudagraph_mode":0,"use_cudagraph":true,"cudagraph_num_of_warmups":0,"cudagraph_capture_sizes":[],"cudagraph_copy_inputs":false,"full_cuda_graph":false,"pass_config":{},"max_capture_size":0,"local_cache_dir":null}
(EngineCore_0 pid=3873791) WARNING 10-26 21:59:34 [parallel_state.py:1000] Distributed backend nccl is not available; falling back to gloo.
[W1026 21:59:38.099691153 ProcessGroupGloo.cpp:516] Warning: Unable to resolve hostname to a (local) address. Using the loopback address as fallback. Manually set the network interface to bind to with GLOO_SOCKET_IFNAME. (function operator())
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0

[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
(EngineCore_0 pid=3873791) INFO 10-26 22:00:18 [parallel_state.py:1134] rank 0 in world size 1 is assigned as DP rank 0, PP rank 0, TP rank 0, EP rank 0
(EngineCore_0 pid=3873791) INFO 10-26 22:00:18 [gpu_model_runner.py:1921] Starting to load model Eslzzyl/Qwen3-4B-Instruct-2507-AWQ...
(EngineCore_0 pid=3873791) INFO 10-26 22:00:18 [gpu_model_runner.py:1953] Loading model from scratch...
(EngineCore_0 pid=3873791) INFO 10-26 22:00:18 [rocm.py:245] Using Triton Attention backend on V1 engine.
(EngineCore_0 pid=3873791) INFO 10-26 22:00:18 [triton_attn.py:257] Using vllm unified attention for TritonAttentionImpl
(EngineCore_0 pid=3873791) INFO 10-26 22:00:19 [weight_utils.py:304] Using model weights format ['*.safetensors']
(EngineCore_0 pid=3873791) INFO 10-26 22:00:19 [weight_utils.py:362] No model.safetensors.index.json found in remote.
Loading safetensors checkpoint shards:   0% Completed | 0/1 [00:00<?, ?it/s]
Loading safetensors checkpoint shards: 100% Completed | 1/1 [00:00<00:00,  2.45it/s]
Loading safetensors checkpoint shards: 100% Completed | 1/1 [00:00<00:00,  2.45it/s]
(EngineCore_0 pid=3873791) 
(EngineCore_0 pid=3873791) INFO 10-26 22:00:19 [default_loader.py:267] Loading weights took 0.46 seconds
(EngineCore_0 pid=3873791) INFO 10-26 22:00:20 [gpu_model_runner.py:1975] Model loading took 2.6628 GiB and 1.149705 seconds
(EngineCore_0 pid=3873791) INFO 10-26 22:00:24 [gpu_worker.py:276] Available KV cache memory: 23.38 GiB
(EngineCore_0 pid=3873791) INFO 10-26 22:00:24 [kv_cache_utils.py:850] GPU KV cache size: 170,224 tokens
(EngineCore_0 pid=3873791) INFO 10-26 22:00:24 [kv_cache_utils.py:854] Maximum concurrency for 131,000 tokens per request: 1.30x
(EngineCore_0 pid=3873791) INFO 10-26 22:00:26 [core.py:217] init engine (profile, create kv cache, warmup model) took 6.04 seconds
(EngineCore_0 pid=3873791) INFO 10-26 22:00:27 [__init__.py:3643] Cudagraph is disabled under eager mode
(APIServer pid=3873368) INFO 10-26 22:00:27 [loggers.py:142] Engine 000: vllm cache_config_info with initialization after num_gpu_blocks is: 10639
(APIServer pid=3873368) INFO 10-26 22:00:27 [async_llm.py:166] Torch profiler disabled. AsyncLLM CPU traces will not be collected.
(APIServer pid=3873368) INFO 10-26 22:00:27 [api_server.py:1680] Supported_tasks: ['generate']
(APIServer pid=3873368) WARNING 10-26 22:00:27 [__init__.py:1678] Default sampling parameters have been overridden by the model's Hugging Face generation config recommended from the model creator. If this is not intended, please relaunch vLLM instance with `--generation-config vllm`.
(APIServer pid=3873368) INFO 10-26 22:00:27 [serving_responses.py:126] Using default chat sampling params from model: {'temperature': 0.7, 'top_k': 20, 'top_p': 0.8}
(APIServer pid=3873368) INFO 10-26 22:00:27 [serving_chat.py:137] Using default chat sampling params from model: {'temperature': 0.7, 'top_k': 20, 'top_p': 0.8}
(APIServer pid=3873368) INFO 10-26 22:00:27 [serving_completion.py:79] Using default completion sampling params from model: {'temperature': 0.7, 'top_k': 20, 'top_p': 0.8}
(APIServer pid=3873368) INFO 10-26 22:00:27 [api_server.py:1957] Starting vLLM API server 0 on http://0.0.0.0:8000
(APIServer pid=3873368) INFO 10-26 22:00:27 [launcher.py:36] Available routes are:
(APIServer pid=3873368) INFO 10-26 22:00:27 [launcher.py:44] Route: /openapi.json, Methods: GET, HEAD
(APIServer pid=3873368) INFO 10-26 22:00:27 [launcher.py:44] Route: /docs, Methods: GET, HEAD
(APIServer pid=3873368) INFO 10-26 22:00:27 [launcher.py:44] Route: /docs/oauth2-redirect, Methods: GET, HEAD
(APIServer pid=3873368) INFO 10-26 22:00:27 [launcher.py:44] Route: /redoc, Methods: GET, HEAD
(APIServer pid=3873368) INFO 10-26 22:00:27 [launcher.py:44] Route: /health, Methods: GET
(APIServer pid=3873368) INFO 10-26 22:00:27 [launcher.py:44] Route: /load, Methods: GET
(APIServer pid=3873368) INFO 10-26 22:00:27 [launcher.py:44] Route: /ping, Methods: POST
(APIServer pid=3873368) INFO 10-26 22:00:27 [launcher.py:44] Route: /ping, Methods: GET
(APIServer pid=3873368) INFO 10-26 22:00:27 [launcher.py:44] Route: /tokenize, Methods: POST
(APIServer pid=3873368) INFO 10-26 22:00:27 [launcher.py:44] Route: /detokenize, Methods: POST
(APIServer pid=3873368) INFO 10-26 22:00:27 [launcher.py:44] Route: /v1/models, Methods: GET
(APIServer pid=3873368) INFO 10-26 22:00:27 [launcher.py:44] Route: /version, Methods: GET
(APIServer pid=3873368) INFO 10-26 22:00:27 [launcher.py:44] Route: /v1/responses, Methods: POST
(APIServer pid=3873368) INFO 10-26 22:00:27 [launcher.py:44] Route: /v1/responses/{response_id}, Methods: GET
(APIServer pid=3873368) INFO 10-26 22:00:27 [launcher.py:44] Route: /v1/responses/{response_id}/cancel, Methods: POST
(APIServer pid=3873368) INFO 10-26 22:00:27 [launcher.py:44] Route: /v1/chat/completions, Methods: POST
(APIServer pid=3873368) INFO 10-26 22:00:27 [launcher.py:44] Route: /v1/completions, Methods: POST
(APIServer pid=3873368) INFO 10-26 22:00:27 [launcher.py:44] Route: /v1/embeddings, Methods: POST
(APIServer pid=3873368) INFO 10-26 22:00:27 [launcher.py:44] Route: /pooling, Methods: POST
(APIServer pid=3873368) INFO 10-26 22:00:27 [launcher.py:44] Route: /classify, Methods: POST
(APIServer pid=3873368) INFO 10-26 22:00:27 [launcher.py:44] Route: /score, Methods: POST
(APIServer pid=3873368) INFO 10-26 22:00:27 [launcher.py:44] Route: /v1/score, Methods: POST
(APIServer pid=3873368) INFO 10-26 22:00:27 [launcher.py:44] Route: /v1/audio/transcriptions, Methods: POST
(APIServer pid=3873368) INFO 10-26 22:00:27 [launcher.py:44] Route: /v1/audio/translations, Methods: POST
(APIServer pid=3873368) INFO 10-26 22:00:27 [launcher.py:44] Route: /rerank, Methods: POST
(APIServer pid=3873368) INFO 10-26 22:00:27 [launcher.py:44] Route: /v1/rerank, Methods: POST
(APIServer pid=3873368) INFO 10-26 22:00:27 [launcher.py:44] Route: /v2/rerank, Methods: POST
(APIServer pid=3873368) INFO 10-26 22:00:27 [launcher.py:44] Route: /scale_elastic_ep, Methods: POST
(APIServer pid=3873368) INFO 10-26 22:00:27 [launcher.py:44] Route: /is_scaling_elastic_ep, Methods: POST
(APIServer pid=3873368) INFO 10-26 22:00:27 [launcher.py:44] Route: /invocations, Methods: POST
(APIServer pid=3873368) INFO 10-26 22:00:27 [launcher.py:44] Route: /metrics, Methods: GET
(APIServer pid=3873368) INFO:     Started server process [3873368]
(APIServer pid=3873368) INFO:     Waiting for application startup.
(APIServer pid=3873368) INFO:     Application startup complete.
(APIServer pid=3873368) INFO 10-26 22:00:59 [chat_utils.py:507] Detected the chat template content format to be 'string'. You can set `--chat-template-content-format` to override this.
(APIServer pid=3873368) INFO:     127.0.0.1:54408 - "POST /v1/chat/completions HTTP/1.1" 200 OK
(EngineCore_0 pid=3873791) WARNING 10-26 22:00:59 [cudagraph_dispatcher.py:102] cudagraph dispatching keys are not initialized. No cudagraph will be used.
(APIServer pid=3873368) INFO 10-26 22:01:09 [loggers.py:123] Engine 000: Avg prompt throughput: 1.5 tokens/s, Avg generation throughput: 18.1 tokens/s, Running: 1 reqs, Waiting: 0 reqs, GPU KV cache usage: 0.1%, Prefix cache hit rate: 0.0%
(APIServer pid=3873368) INFO 10-26 22:01:19 [loggers.py:123] Engine 000: Avg prompt throughput: 0.0 tokens/s, Avg generation throughput: 21.4 tokens/s, Running: 1 reqs, Waiting: 0 reqs, GPU KV cache usage: 0.2%, Prefix cache hit rate: 0.0%
(APIServer pid=3873368) INFO 10-26 22:01:29 [loggers.py:123] Engine 000: Avg prompt throughput: 0.0 tokens/s, Avg generation throughput: 21.3 tokens/s, Running: 1 reqs, Waiting: 0 reqs, GPU KV cache usage: 0.4%, Prefix cache hit rate: 0.0%
^C(APIServer pid=3873368) INFO 10-26 22:01:30 [launcher.py:101] Shutting down FastAPI HTTP server.
(APIServer pid=3873368) INFO:     Shutting down
(APIServer pid=3873368) INFO:     Waiting for connections to close. (CTRL+C to force quit)
^C^C^C(APIServer pid=3873368) INFO:     Waiting for application shutdown.
```

Versions:

```
$ python -c "import torch, triton; print(torch.__version__, triton.__version__)"
2.9.0a0+rocmsdk20250903 3.4.0
```
