### PR TITLE
Remove pinned transformers==5.3.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -141,10 +141,6 @@ RUN echo "Installing Custom RCCL..." && \
   find /opt/venv -name "librccl.so.1" -exec cp -fv /tmp/librccl.so.1 {} + && \
   rm /tmp/librccl.so.1
 
-# 10. Force Upgrade Transformers (User Override)
-# Required for GLM Flash, Qwen 3.5 etc.... vLLM reports incompatibility with transformers >= 5, 
-# but this version (5.3.0) has been tested and confirmed working.
-RUN python -m pip install transformers==5.3.0
 
 RUN chmod -R a+rwX /opt
 


### PR DESCRIPTION
## Summary

- Removes the manual `pip install transformers==5.3.0` override from the Dockerfile

## Reason

vLLM PR [#30566](https://github.com/vllm-project/vllm/pull/30566) (merged 2026-04-15) updated the `transformers` constraint from `< 5` to `!= 5.0.*, != 5.1.*, != 5.2.*, != 5.3.*, != 5.4.*, != 5.5.0`.

This means:
- The pin is no longer needed — vLLM itself now resolves a compatible v5 version
- `5.3.0` is now explicitly **excluded** by vLLM's own constraint, so the pin actively conflicts
- Removing it lets pip resolve the latest compatible version (currently `5.5.3`, which is what vLLM's CI tests against)