### PR TITLE
Add BuildKit registry cache to speed up rebuilds

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -103,7 +103,8 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           provenance: false
           sbom: false
-          no-cache: true
+          cache-from: type=registry,ref=docker.io/${{ env.IMAGE_REPO }}:buildcache
+          cache-to: type=registry,ref=docker.io/${{ env.IMAGE_REPO }}:buildcache,mode=max
 
       - name: Prune buildx cache
         if: always()


### PR DESCRIPTION
## Summary

Adds BuildKit registry cache (`type=registry`) to the build-and-publish workflow, persisting layer cache between runs as a `:buildcache` tag in the same repository.

## Motivation

The current workflow uses `no-cache: true`, meaning every build starts cold. Stable layers like the TheRock ROCm SDK and PyTorch nightly take the majority of build time and rarely change. With registry cache, these layers are reused on subsequent builds when unchanged.

## Details

- Cache is stored at `<IMAGE_REPO>:buildcache` using `mode=max` (caches all intermediate layers, not just the final stage)
- Works with Docker Hub free tier — `type=registry` is a standard BuildKit feature and does not require Docker Build Cloud
- First build after merging will still be full duration (cold cache); subsequent builds benefit from cached layers

## No `no-cache` removal note

The existing `no-cache: true` flag has been replaced by the cache directives. BuildKit's cache invalidation handles correctness — layers are rebuilt when their inputs change.