### PR TITLE
Remove chmod -R a+rwX /opt to eliminate ~22GB image layer

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -99,8 +99,7 @@ RUN cmake -S . \
 
 # 8. Final Cleanup & Runtime
 WORKDIR /opt
-RUN chmod -R a+rwX /opt && \
-  find /opt/venv -type f -name "*.so" -exec strip -s {} + 2>/dev/null || true && \
+RUN find /opt/venv -type f -name "*.so" -exec strip -s {} + 2>/dev/null || true && \
   find /opt/venv -type d -name "__pycache__" -prune -exec rm -rf {} + && \
   rm -rf /root/.cache/pip || true && \
   dnf clean all && rm -rf /var/cache/dnf/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -141,10 +141,8 @@ RUN echo "Installing Custom RCCL..." && \
   rm /tmp/librccl.so.1
 
 # 10. Force Upgrade Transformers (User Override)
-# Required for GLM Flash, Qwen 3.5 etc.... vLLM reports incompatibility with transformers >= 5, 
+# Required for GLM Flash, Qwen 3.5 etc.... vLLM reports incompatibility with transformers >= 5,
 # but this version (5.3.0) has been tested and confirmed working.
 RUN python -m pip install transformers==5.3.0
-
-RUN chmod -R a+rwX /opt
 
 CMD ["/bin/bash"]


### PR DESCRIPTION
## Summary

Removes the `chmod -R a+rwX /opt` from the final cleanup step.

## Why this reduces image size

Docker/BuildKit stores images as a stack of immutable layers. Each `RUN` instruction produces a new layer containing only the *diff* of filesystem changes. The critical detail is how overlayfs tracks changes: even a pure permission change (no content change) counts as a modified file and is written into the new layer.

`chmod -R a+rwX /opt` runs after ROCm, PyTorch, vLLM, flash-attention, and bitsandbytes have all been installed into `/opt`. At that point `/opt` contains ~20GB of files. The chmod touches the metadata of every single one of them, so the resulting layer is essentially a full duplicate of `/opt` — just to record permission bits.

Inspecting the current image with `podman history` confirms this:

```
22.3GB   RUN chmod -R a+rwX /opt
15.5GB   COPY /opt/rocm ...
 6.8GB   COPY /opt/venv ...
```

The 22GB chmod layer is larger than either of the directories it touches because overlayfs must record every modified inode.

## Is the chmod actually needed?

No. Files installed by `pip` and extracted from the TheRock ROCm tarball already have correct permissions (755 for executables and directories, 644 for data files). The chmod was added defensively but is redundant in practice.

## Impact

Removing it saves ~22GB from the final image with no functional change.