### PR TITLE
build: make vLLM commit pinnable via VLLM_COMMIT build-arg

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,8 +43,14 @@ RUN git clone https://github.com/ROCm/flash-attention.git &&\
   cd /opt && rm -rf /opt/flash-attention
 
 # 6. Clone vLLM
+# Optional: pin to a specific vLLM commit for reproducible builds.
+# Defaults to empty (tracks upstream HEAD). Override with --build-arg VLLM_COMMIT=<sha>.
+ARG VLLM_COMMIT=
 RUN git clone https://github.com/vllm-project/vllm.git /opt/vllm
 WORKDIR /opt/vllm
+RUN if [ -n "$VLLM_COMMIT" ]; then \
+      echo "Pinning vLLM to commit $VLLM_COMMIT" && git checkout "$VLLM_COMMIT"; \
+    fi
 
 # --- PATCHING ---
 COPY scripts/patch_strix.py /opt/vllm/patch_strix.py


### PR DESCRIPTION
## Summary
Adds an optional `ARG VLLM_COMMIT` to the Dockerfile that, when set, checks out a specific vLLM revision before patching and building. Default is empty, so existing behavior (tracking `vllm-project/vllm` HEAD) is preserved for everyone who doesn't opt in.

## Why
vLLM's `main` moves fast and occasionally regresses on gfx1151 (recent examples: kernel warmup leaks, hybrid Mamba KV-cache overestimation). Being able to pin a known-good SHA on the CLI means users can roll back without editing the Dockerfile or maintaining a fork, and CI can produce reproducible images.

## Usage
```
podman build --build-arg VLLM_COMMIT=fa9e68022 ...
```
Unset / empty → current behavior (HEAD).

## Test plan
- [x] Build with `--build-arg VLLM_COMMIT=<sha>` — checkout step runs, commit matches
- [x] Build without the arg — `git checkout` step is a no-op, HEAD is retained
- [ ] CI build (you'd know the runner specifics better than me)