### PR TITLE
build: make MAX_JOBS overridable via build-arg

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -64,7 +64,10 @@ ENV VLLM_TARGET_DEVICE="rocm"
 ENV PYTORCH_ROCM_ARCH="gfx1151"
 ENV HIP_ARCHITECTURES="gfx1151"          
 ENV AMDGPU_TARGETS="gfx1151"              
-ENV MAX_JOBS="4"
+# Parallel build jobs. Default tuned for the GitHub Actions runner (~7 GB RAM);
+# override with --build-arg MAX_JOBS=N when building locally on larger machines.
+ARG MAX_JOBS=4
+ENV MAX_JOBS=${MAX_JOBS}
 
 # --- CRITICAL FIX FOR SEGFAULT ---
 # We force the Host Compiler (CC/CXX) to be the ROCm Clang, not Fedora GCC.


### PR DESCRIPTION
## Summary
Turn the hard-coded `ENV MAX_JOBS=\"4\"` into an `ARG MAX_JOBS=4` plus `ENV MAX_JOBS=\${MAX_JOBS}`. Default stays at 4, so existing CI on the GitHub Actions runner is unaffected.

## Why
4 is the right number for the Actions runner (~7 GB RAM), but that choice bakes into the image for anyone building locally on a workstation too. Users on bigger hardware currently have to patch the Dockerfile to use their cores. Same rationale as #43: community-friendly knob, opt-in, zero impact when unset.

## Usage
```
podman build --build-arg MAX_JOBS=32 ...
```

The big winner is the vLLM C++/HIP compilation step — each translation unit is single-threaded but there are enough of them that throughput scales well across CPUs.

## Test plan
- [x] Build without `--build-arg MAX_JOBS=...` — `MAX_JOBS=4` at runtime (unchanged)
- [x] Build with `--build-arg MAX_JOBS=32` — `MAX_JOBS=32` at runtime, build is substantially faster on a 32-core host
- [x] CI run on Actions (default path) — same duration as before