### PR TITLE
refresh_toolbox.sh: keep a local date-stamped tag after pulling

### DIFF
--- a/refresh_toolbox.sh
+++ b/refresh_toolbox.sh
@@ -51,6 +51,21 @@ $RUNTIME pull "$IMAGE"
 new_id="$($RUNTIME image inspect --format '{{.Id}}' "$IMAGE" 2>/dev/null || true)"
 new_digest="$($RUNTIME image inspect --format '{{.Digest}}' "$IMAGE" 2>/dev/null || true)"
 
+# Pin the pulled image under a local date-stamped tag so rollbacks survive
+# the next :latest refresh (which would otherwise untag this image -> cleanup).
+# Format matches the CI's own YYYYMMDD-HHMMSS tag, sourced from the
+# org.opencontainers.image.created label.
+repo_no_tag="${IMAGE%:*}"
+created_iso="$($RUNTIME image inspect --format '{{index .Labels "org.opencontainers.image.created"}}' "$IMAGE" 2>/dev/null || true)"
+if [[ -n "$created_iso" && "$created_iso" != "<no value>" ]]; then
+    date_tag_value="$(date -u -d "$created_iso" +%Y%m%d-%H%M%S 2>/dev/null || true)"
+    if [[ -n "$date_tag_value" ]]; then
+        date_tag="${repo_no_tag}:${date_tag_value}"
+        echo "🏷  Local tag: $date_tag"
+        $RUNTIME tag "$new_id" "$date_tag" >/dev/null 2>&1 || true
+    fi
+fi
+
 echo "📦 Recreating $MANAGER: $TOOLBOX_NAME"
 echo "   Options: $OPTIONS"
 


### PR DESCRIPTION
## Summary
After pulling the image, apply a second local tag `YYYYMMDD-HHMMSS` derived from the `org.opencontainers.image.created` label (same format the build workflow's `docker/metadata-action` already uses for one of its tags).

## Why
Right now each refresh orphans the previous `:latest` image. It loses its only tag, becomes `<none>:<none>`, and the cleanup pass at the bottom of the script removes it. That means rollback requires re-pulling a specific tag from Docker Hub every time — there's no local breadcrumb trail.

With this change, every pulled build keeps a stable local handle. Users can roll back instantly with e.g.
```
podman run docker.io/kyuz0/vllm-therock-gfx1151:20260418-092133 ...
```
(or via `vllm-run --image kyuz0:20260418-092133` in my helper, which already surfaces local tags for completion).

The existing cleanup keys off exact tag strings (`:latest` and its `<none>` remnant), so the new timestamp tag survives the next `:latest` rotation untouched.

## Test plan
- [x] Fresh pull: new image gets both `:latest` and `:YYYYMMDD-HHMMSS` tags
- [x] Next refresh with a different `:latest` digest: the prior timestamp-tagged image stays; only the orphaned `:<none>` prior-`:latest` is removed
- [x] Label missing (e.g., old image without metadata): the block is a no-op and script proceeds normally