### PR TITLE
fix: skip aiter lib/lib64 merge when lib64 is a symlink to lib

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -59,10 +59,15 @@ RUN git clone https://github.com/ROCm/flash-attention.git && \
 # Fix Fedora lib vs lib64 split: setup.py install writes to lib/, pip to lib64/.
 # flash-attention's find_packages() may install a partial aiter copy into lib/.
 # Merge any straggler files from lib/ into lib64/ so Python finds everything.
-RUN if [ -d /opt/venv/lib/python3.12/site-packages/aiter ]; then \
-      cp -rn /opt/venv/lib/python3.12/site-packages/aiter/* \
-             /opt/venv/lib64/python3.12/site-packages/aiter/ 2>/dev/null || true; \
-      rm -rf /opt/venv/lib/python3.12/site-packages/aiter; \
+# When lib64 is a symlink to lib (Fedora's default venv layout), the two
+# site-packages dirs resolve to the same path — skip the merge, since the
+# cp-into-self then rm-rf would delete the entire aiter package.
+RUN lib_sp=/opt/venv/lib/python3.12/site-packages; \
+    lib64_sp=/opt/venv/lib64/python3.12/site-packages; \
+    if [ "$(readlink -f "$lib_sp")" != "$(readlink -f "$lib64_sp")" ] && \
+       [ -d "$lib_sp/aiter" ]; then \
+      cp -rn "$lib_sp/aiter/"* "$lib64_sp/aiter/" 2>/dev/null || true; \
+      rm -rf "$lib_sp/aiter"; \
     fi
 
 # 6. Clone vLLM


### PR DESCRIPTION
## Summary

The aiter runtime package is not importable in the published image. `amd_aiter`'s `RECORD` file lists `aiter/__init__.py` and all submodules, but on disk only `aiter_meta/` is present; `import aiter` raises `ModuleNotFoundError`.

**Root cause.** On Fedora 43 (the base image), `python -m venv` creates `/opt/venv/lib64` as a **symlink to `/opt/venv/lib`**. The aiter merge step runs:

```sh
cp -rn /opt/venv/lib/.../aiter/*  /opt/venv/lib64/.../aiter/
rm -rf /opt/venv/lib/.../aiter
```

Because `lib64` resolves to `lib`, both paths point at the same directory. `cp -rn` refuses to copy files onto themselves (no-op), and the `rm -rf` then deletes the entire `aiter` package.

Downstream effects:
- `import aiter` fails → ROCM_ATTN can't use aiter's Triton FA (Patch 8 softens the import so flash_attn itself still loads).
- vLLM's ViT attention fallback path silently degrades for anything that wanted aiter.

## Fix

Skip the merge when the two site-packages dirs resolve to the same path. Non-Fedora layouts with genuinely separate `lib/lib64` still run the original merge.

```sh
lib_sp=/opt/venv/lib/python3.12/site-packages
lib64_sp=/opt/venv/lib64/python3.12/site-packages
if [ "$(readlink -f "$lib_sp")" != "$(readlink -f "$lib64_sp")" ] && \
   [ -d "$lib_sp/aiter" ]; then
  cp -rn "$lib_sp/aiter/"* "$lib64_sp/aiter/" 2>/dev/null || true
  rm -rf "$lib_sp/aiter"
fi
```

## Evidence

**In the current `kyuz0/vllm-therock-gfx1151:latest` image:**

```
$ podman run --rm kyuz0/vllm-therock-gfx1151:latest bash -lc 'ls -ld /opt/venv/lib64 && python -c "import aiter"'
lrwxrwxrwx 1 root root 3 ... /opt/venv/lib64 -> lib
ModuleNotFoundError: No module named 'aiter'

$ head -1 /opt/venv/lib64/python3.12/site-packages/amd_aiter-*.dist-info/RECORD
aiter/__init__.py,sha256=...                        # ← but not on disk
```

**Sandbox reproduction of the merge step:**

| Scenario | Old logic | Fixed logic |
|---|---|---|
| `lib64 → lib` symlink (Fedora) | `aiter/` deleted ❌ | `aiter/` preserved ✅ |
| Separate `lib/lib64` directories | merge runs ✅ | merge runs ✅ |

## Test plan

I'd normally rebuild locally before posting, but wanted to flag this promptly since you mentioned being mid-rebuild. Happy to do a local rebuild to verify once your current experiments settle — just let me know.

- [ ] Rebuild image; confirm `/opt/venv/.../aiter/__init__.py` exists
- [ ] `python -c "import aiter; print(aiter.__file__)"` succeeds
- [ ] `python -c "from aiter.ops.triton._triton_kernels.flash_attn_triton_amd import flash_attn_2"` succeeds
- [ ] Existing vLLM workflows unchanged on text path