### PR TITLE
add EAGLE/MTP spec-decode passthrough + Mistral-Medium-3.5 / Nemotron-Omni / Qwen3.6-27B

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -113,6 +113,14 @@ RUN export HIP_DEVICE_LIB_PATH=$(find /opt/rocm -type d -name bitcode -print -qu
 
 RUN python -m pip install ray
 
+# Audio extras for omni-modal models (Nemotron-Omni, Qwen3-Omni, Voxtral,
+# Ultravox, ...). librosa is installed --no-deps to skip numba/llvmlite,
+# which collides with ROCm libLLVM (same workaround as the voice-toolbox).
+RUN python -m pip install --no-cache-dir \
+      av soundfile audioread pooch lazy_loader msgpack cffi decorator \
+    && python -m pip install --no-cache-dir --no-deps librosa \
+    && rm -rf /root/.cache/pip
+
 # --- bitsandbytes (ROCm) ---
 WORKDIR /opt
 RUN git clone -b rocm_enabled_multi_backend https://github.com/ROCm/bitsandbytes.git

--- a/README.md
+++ b/README.md
@@ -58,6 +58,10 @@ View full benchmarks at: [https://kyuz0.github.io/amd-strix-halo-vllm-toolboxes/
 | [`cyankiwi/Qwen3.5-122B-A10B-AWQ-4bit`](https://huggingface.co/cyankiwi/Qwen3.5-122B-A10B-AWQ-4bit) | 122B / AWQ 4-bit | 1 GPU (TP=1, 2) |
 | [`cyankiwi/Qwen3.5-122B-A10B-AWQ-8bit`](https://huggingface.co/cyankiwi/Qwen3.5-122B-A10B-AWQ-8bit) | 122B / AWQ 8-bit | **2 GPUs (TP=2 Only)** |
 | [`cyankiwi/MiniMax-M2.7-AWQ-4bit`](https://huggingface.co/cyankiwi/MiniMax-M2.7-AWQ-4bit) | N/A / AWQ 4-bit | **2 GPUs (TP=2 Only)** |
+| [`mistralai/Mistral-Medium-3.5-128B`](https://huggingface.co/mistralai/Mistral-Medium-3.5-128B) | 128B / FP8 (or W4A16/GGUF) + EAGLE | 1 GPU (TP=1) |
+| [`unsloth/NVIDIA-Nemotron-3-Nano-Omni-30B-A3B-Reasoning-GGUF`](https://huggingface.co/unsloth/NVIDIA-Nemotron-3-Nano-Omni-30B-A3B-Reasoning-GGUF) | 30B-A3B / GGUF (text+image+audio+video) | 1 GPU (TP=1) |
+| [`unsloth/Qwen3.6-27B-GGUF`](https://huggingface.co/unsloth/Qwen3.6-27B-GGUF) | 27B / GGUF + MTP | 1 GPU (TP=1) |
+| [`cyankiwi/Qwen3.6-27B-AWQ-INT4`](https://huggingface.co/cyankiwi/Qwen3.6-27B-AWQ-INT4) | 27B / AWQ 4-bit + MTP | 1 GPU (TP=1) |
 
 
 ---

--- a/scripts/install_deps.sh
+++ b/scripts/install_deps.sh
@@ -2,11 +2,14 @@
 set -e
 
 # 1. System Base & Build Tools
-# Added 'gperftools-libs' for tcmalloc (fixes double-free)
+# Added 'gperftools-libs' for tcmalloc (fixes double-free).
+# Added libsndfile / flac / opus / libogg / libvorbis for soundfile + pyav
+# audio decoding (vLLM omni-modal: Nemotron-Omni, Qwen3-Omni, Voxtral, ...).
 dnf -y install --setopt=install_weak_deps=False --nodocs \
   python3.12 python3.12-devel git rsync libatomic bash ca-certificates curl \
   gcc gcc-c++ binutils make ffmpeg-free \
   cmake ninja-build aria2c tar xz vim nano dialog \
   libdrm-devel zlib-devel openssl-devel pgrep \
+  libsndfile flac opus opusfile libogg libvorbis \
   numactl-devel gperftools-libs iproute libibverbs-utils patch perftest ping iperf3 perfquery \
   && dnf clean all && rm -rf /var/cache/dnf/*

--- a/scripts/models.py
+++ b/scripts/models.py
@@ -1,3 +1,39 @@
+# Per-model launcher config.
+#
+# Required: max_num_seqs (str), max_tokens (str). Optional: trust_remote (bool),
+# valid_tp (list[int], default [1]), enforce_eager (bool), env (dict).
+#
+# Optional vllm-serve passthrough (read with .get() so older entries are
+# unaffected): quantization, served_model_name, tokenizer_mode, config_format,
+# load_format, hf_overrides (dict), speculative_config (dict, see
+# SpeculativeMethod in vllm/config/speculative.py for valid `method` values),
+# attention_backend (TRITON_ATTN/ROCM_ATTN/AITER), extra_args (list[str]),
+# notes (str). The stringly-typed enum fields are validated by start_vllm.py
+# before exec.
+
+# Shared extra_args groups so multi-entry families don't drift.
+_QWEN3_TOOL_ARGS = [
+    "--reasoning-parser", "qwen3",
+    "--enable-auto-tool-choice",
+    "--tool-call-parser", "qwen3_coder",
+]
+
+_MISTRAL_TOOL_ARGS = [
+    "--enable-auto-tool-choice",
+    "--tool-call-parser", "mistral",
+    "--reasoning-parser", "mistral",
+]
+
+_NEMOTRON_OMNI_TOOL_ARGS = [
+    "--reasoning-parser", "nemotron_v3",
+    "--enable-auto-tool-choice",
+    "--tool-call-parser", "qwen3_coder",
+    "--video-pruning-rate", "0.5",
+    "--media-io-kwargs", '{"video":{"num_frames":512,"fps":1}}',
+    "--limit-mm-per-prompt", '{"image":4,"video":1,"audio":2}',
+]
+
+
 MODEL_TABLE = {
     # 1. Llama 3.1 8B Instruct
     # MAD uses 131k tokens. We scale to 32k for 32GB VRAM safety.
@@ -7,7 +43,7 @@ MODEL_TABLE = {
         "max_num_seqs": "64",
         "max_tokens": "32768"
     },
-    
+
     "google/gemma-4-26B-A4B-it": {
         "trust_remote": False,
         "enforce_eager": False,
@@ -31,7 +67,7 @@ MODEL_TABLE = {
         "max_num_seqs": "64",
         "max_tokens": "8192"
     },
-    
+
     "openai/gpt-oss-120b": {
         "trust_remote": True,
         "valid_tp": [1],
@@ -48,17 +84,17 @@ MODEL_TABLE = {
 
     "cyankiwi/Qwen3.6-35B-A3B-AWQ-4bit": {
         "trust_remote": True,
-        "valid_tp": [1], 
-        "enforce_eager": True, 
+        "valid_tp": [1],
+        "enforce_eager": True,
         "env": {"VLLM_USE_TRITON_AWQ": "1"},
         "max_num_seqs": "64",
         "max_tokens": "16384"
-    },  
+    },
 
     "cyankiwi/Qwen3.5-122B-A10B-AWQ-4bit": {
         "trust_remote": True,
         "valid_tp": [1,2], # Too big for single GPU
-        "enforce_eager": True, 
+        "enforce_eager": True,
         "env": {"VLLM_USE_TRITON_AWQ": "1"},
         "max_num_seqs": "64",
         "max_tokens": "16384"
@@ -67,7 +103,7 @@ MODEL_TABLE = {
     "cyankiwi/Qwen3.5-122B-A10B-AWQ-8bit": {
         "trust_remote": True,
         "valid_tp": [2], # Too big for single GPU
-        "enforce_eager": True, 
+        "enforce_eager": True,
         "env": {"VLLM_USE_TRITON_AWQ": "1"},
         "max_num_seqs": "64",
         "max_tokens": "16384"
@@ -80,6 +116,73 @@ MODEL_TABLE = {
         "env": {"VLLM_USE_TRITON_AWQ": "1"},
         "max_num_seqs": "64",
         "max_tokens": "16384"
+    },
+
+    # Mistral-Medium-3.5-128B (Mistral3 dense + Pixtral vision) paired with the
+    # official Mistral-Medium-3.5-128B-EAGLE FP8 draft. The mistral tokenizer/
+    # config/load formats are required for the Tekken tokenizer + tool-calling.
+    "mistralai/Mistral-Medium-3.5-128B": {
+        "trust_remote": False,
+        "valid_tp": [1],
+        "enforce_eager": True,
+        "max_num_seqs": "4",
+        "max_tokens": "32768",
+        "tokenizer_mode": "mistral",
+        "config_format": "mistral",
+        "load_format": "mistral",
+        "speculative_config": {
+            "method": "eagle",
+            "model": "mistralai/Mistral-Medium-3.5-128B-EAGLE",
+            "num_speculative_tokens": 3,
+        },
+        "extra_args": _MISTRAL_TOOL_ARGS,
+    },
+
+    # NVIDIA Nemotron-3 Nano Omni (NemotronH_Nano_Omni_Reasoning_V3 ->
+    # nano_nemotron_vl). Hybrid Mamba2-Transformer MoE with vision (Radio),
+    # audio (Parakeet) and video (EVS). Patch_11 wires the nemotron_v2_vl
+    # GGUF projector. Audio extras are installed by install_deps.sh + Dockerfile.
+    "unsloth/NVIDIA-Nemotron-3-Nano-Omni-30B-A3B-Reasoning-GGUF": {
+        "trust_remote": True,
+        "valid_tp": [1],
+        "enforce_eager": True,
+        "quantization": "gguf",
+        "max_num_seqs": "8",
+        "max_tokens": "131072",
+        "extra_args": _NEMOTRON_OMNI_TOOL_ARGS,
+    },
+
+    # Qwen3.6-27B GGUF + native MTP head. TP=1 only on hybrid GDN until
+    # vllm-project/vllm#41190 closes. Pre-quant GGUFs typically drop the MTP
+    # tensors; falls back to non-MTP if the head isn't found.
+    "unsloth/Qwen3.6-27B-GGUF": {
+        "trust_remote": True,
+        "valid_tp": [1],
+        "enforce_eager": True,
+        "quantization": "gguf",
+        "max_num_seqs": "8",
+        "max_tokens": "131072",
+        "speculative_config": {
+            "method": "qwen3_next_mtp",
+            "num_speculative_tokens": 2,
+        },
+        "extra_args": _QWEN3_TOOL_ARGS,
+    },
+
+    # AWQ-INT4 safetensors variant of Qwen3.6-27B with the MTP head intact.
+    # Use this when the GGUF + MTP path above can't find the MTP tensors.
+    "cyankiwi/Qwen3.6-27B-AWQ-INT4": {
+        "trust_remote": True,
+        "valid_tp": [1],
+        "enforce_eager": True,
+        "max_num_seqs": "8",
+        "max_tokens": "131072",
+        "env": {"VLLM_USE_TRITON_AWQ": "1"},
+        "speculative_config": {
+            "method": "qwen3_next_mtp",
+            "num_speculative_tokens": 2,
+        },
+        "extra_args": _QWEN3_TOOL_ARGS,
     },
 
 }

--- a/scripts/patch_strix.py
+++ b/scripts/patch_strix.py
@@ -311,6 +311,90 @@ except Exception:
             p_rocm_plat.write_text(txt)
             print(" -> Patched vllm/platforms/rocm.py (ROCM-21812 APU VRAM Dynamic Margin)")
 
+    # Patch 11: vllm/transformers_utils/gguf_utils.py
+    # extract_vision_config_from_gguf only special-cases Gemma3, and
+    # maybe_patch_hf_config_from_gguf only wires the vision tower when
+    # model_type is gemma3{,_text}. Add projector branches for nemotron_v2_vl
+    # (Radio, used by NanoNemotronVL) and pixtral (Mistral3), and plumb the
+    # vision_config into the parent for mistral3/nemotron_h{,_moe} so an
+    # mmproj.gguf sibling is actually exposed at load time.
+    p_gguf = Path('vllm/transformers_utils/gguf_utils.py')
+    if p_gguf.exists():
+        txt = p_gguf.read_text()
+
+        # Branch in extract_vision_config_from_gguf
+        if '"nemotron_v2_vl"' not in txt and 'projector_type == VisionProjectorType.GEMMA3' in txt:
+            txt = txt.replace(
+                '    if projector_type == VisionProjectorType.GEMMA3:\n'
+                '        # Gemma3 doesn\'t use the vision pooling head (multihead attention)\n'
+                '        # This is a vLLM-specific parameter used in SiglipVisionTransformer\n'
+                '        config_params["vision_use_head"] = False\n'
+                '        logger.info("Detected Gemma3 projector, disabling vision pooling head")',
+                '    if projector_type == VisionProjectorType.GEMMA3:\n'
+                '        config_params["vision_use_head"] = False\n'
+                '        logger.info("Detected Gemma3 projector, disabling vision pooling head")\n'
+                '    elif projector_type == "nemotron_v2_vl":\n'
+                '        # Nemotron-3 Nano Omni: C-RADIOv4-H + 2-layer MLP projector. The vision\n'
+                '        # tower has its own pooling so we disable the SigLIP head here too.\n'
+                '        config_params["vision_use_head"] = False\n'
+                '        logger.info("Detected nemotron_v2_vl projector (Nano Omni / Radio)")\n'
+                '    elif projector_type == "pixtral":\n'
+                '        # Mistral3 Pixtral: 48-layer ViT, image up to 1540px, patch 14.\n'
+                '        # The projector handles its own break tokens; no SigLIP pooling head.\n'
+                '        config_params["vision_use_head"] = False\n'
+                '        logger.info("Detected pixtral projector (Mistral3)")'
+            )
+
+        # Patch maybe_patch_hf_config_from_gguf to also wire Mistral3 / NemotronH.
+        # Strategy: keep the existing Gemma3 branch verbatim; append additional
+        # branches that run only when model_type matches and a vision_config was
+        # successfully extracted.
+        if "is_mistral3 = hf_config.model_type" not in txt and "is_gemma3 = hf_config.model_type" in txt:
+            txt = txt.replace(
+                '        is_gemma3 = hf_config.model_type in ("gemma3", "gemma3_text")\n'
+                '        if vision_config is not None and is_gemma3:\n'
+                '            new_hf_config = Gemma3Config(\n'
+                '                text_config=text_config,\n'
+                '                vision_config=vision_config,\n'
+                '                architectures=["Gemma3ForConditionalGeneration"],\n'
+                '            )\n'
+                '            hf_config = new_hf_config\n',
+                '        is_gemma3 = hf_config.model_type in ("gemma3", "gemma3_text")\n'
+                '        is_mistral3 = hf_config.model_type in ("mistral3", "ministral3")\n'
+                '        is_nemotron_h_omni = hf_config.model_type in (\n'
+                '            "nemotron_h_moe", "nemotron_h", "nemotron_v2_vl",\n'
+                '        )\n'
+                '        if vision_config is not None and is_gemma3:\n'
+                '            new_hf_config = Gemma3Config(\n'
+                '                text_config=text_config,\n'
+                '                vision_config=vision_config,\n'
+                '                architectures=["Gemma3ForConditionalGeneration"],\n'
+                '            )\n'
+                '            hf_config = new_hf_config\n'
+                '        elif vision_config is not None and is_mistral3:\n'
+                '            # Mistral3 keeps text_config under .text_config and the vision\n'
+                '            # tower under .vision_config. Side-load both onto the parent.\n'
+                '            try:\n'
+                '                hf_config.vision_config = vision_config\n'
+                '                hf_config.architectures = ["Mistral3ForConditionalGeneration"]\n'
+                '                logger.info("Patched HF config for Mistral3 GGUF (Pixtral mmproj)")\n'
+                '            except Exception as _e:\n'
+                '                logger.warning("Mistral3 mmproj wiring failed: %s", _e)\n'
+                '        elif vision_config is not None and is_nemotron_h_omni:\n'
+                '            # NanoNemotronVL expects vision_config under .vision_config and\n'
+                '            # registers the multimodal head from architectures.\n'
+                '            try:\n'
+                '                hf_config.vision_config = vision_config\n'
+                '                if not getattr(hf_config, "architectures", None):\n'
+                '                    hf_config.architectures = ["NemotronH_Nano_Omni_Reasoning_V3"]\n'
+                '                logger.info("Patched HF config for Nemotron-Omni GGUF (nemotron_v2_vl mmproj)")\n'
+                '            except Exception as _e:\n'
+                '                logger.warning("Nemotron-Omni mmproj wiring failed: %s", _e)\n'
+            )
+
+        p_gguf.write_text(txt)
+        print(" -> Patched vllm/transformers_utils/gguf_utils.py (Patch_11: nemotron_v2_vl + pixtral GGUF projector)")
+
     print("Successfully patched vLLM/Environment for Strix Halo.")
 
 if __name__ == "__main__":

--- a/scripts/start_vllm.py
+++ b/scripts/start_vllm.py
@@ -84,7 +84,7 @@ def get_verified_config(model_id, tp_size, max_seqs):
     """
     default_config = {
         "ctx": "auto",
-        "util": 0.90 # Safe default
+        "util": float(models.GPU_UTIL),
     }
     
     if not RESULTS_FILE.exists():
@@ -147,14 +147,34 @@ def nuke_vllm_cache():
 def configure_and_launch(model_idx, gpu_count):
     model_id = MODELS_TO_RUN[model_idx]
     config = MODEL_TABLE[model_id]
-    
+
+    # Validate stringly-typed fields here so a typo surfaces with the
+    # offending model_id rather than as an opaque vllm argparse error.
+    _VALID_ENUMS = {
+        "tokenizer_mode": {"auto", "mistral", "slow", "custom"},
+        "config_format": {"auto", "mistral", "hf"},
+        "load_format": {
+            "auto", "mistral", "safetensors", "npcache", "dummy",
+            "tensorizer", "runai_streamer", "sharded_state", "gguf",
+            "bitsandbytes", "pt",
+        },
+    }
+    for _f, _valid in _VALID_ENUMS.items():
+        _v = config.get(_f)
+        if _v and _v not in _valid:
+            raise ValueError(
+                f"models.py {model_id!r}: {_f}={_v!r} not in {sorted(_valid)}"
+            )
+
     # Static Config
     valid_tps = config.get("valid_tp", [1])
     max_tp = max(valid_tps) if valid_tps else 1
-    
+
     # Defaults
     current_tp = min(gpu_count, max_tp)
-    current_seqs = 1 # Default to 1 concurrent user/request for stability
+    # Seed concurrency from the entry's max_num_seqs. Speculative-decode entries
+    # rely on this >= 4 to have a batch to amortize the draft cost.
+    current_seqs = int(config.get("max_num_seqs", 1))
     
     # Initial Lookup
     verified = get_verified_config(model_id, current_tp, current_seqs)
@@ -165,6 +185,17 @@ def configure_and_launch(model_idx, gpu_count):
     use_eager = config.get("enforce_eager", False) # Default to model config, usually False
     attn_backends = ["Triton", "ROCm (CK)", "AITER"]
     current_attn_backend = "Triton" # Default to Triton
+
+    # Per-model attention backend override.
+    _attn_alias = {"TRITON_ATTN": "Triton", "ROCM_ATTN": "ROCm (CK)", "AITER": "AITER"}
+    _attn_override = config.get("attention_backend")
+    if _attn_override:
+        if _attn_override not in _attn_alias:
+            raise ValueError(
+                f"models.py {model_id!r}: attention_backend={_attn_override!r} "
+                f"not in {list(_attn_alias)}"
+            )
+        current_attn_backend = _attn_alias[_attn_override]
     
     name = model_id.split("/")[-1]
     
@@ -285,9 +316,27 @@ def configure_and_launch(model_idx, gpu_count):
         "--gpu-memory-utilization", str(current_util),
         "--dtype", "auto"
     ]
-    
+
     if config.get("trust_remote"): cmd.append("--trust-remote-code")
     if use_eager: cmd.append("--enforce-eager")
+
+    # Optional structured fields. .get() keeps existing entries unaffected.
+    if (q := config.get("quantization")):
+        cmd.extend(["--quantization", q])
+    if (n := config.get("served_model_name")):
+        cmd.extend(["--served-model-name", n])
+    if (tm := config.get("tokenizer_mode")):
+        cmd.extend(["--tokenizer-mode", tm])
+    if (cf := config.get("config_format")):
+        cmd.extend(["--config-format", cf])
+    if (lf := config.get("load_format")):
+        cmd.extend(["--load-format", lf])
+    if (ho := config.get("hf_overrides")):
+        cmd.extend(["--hf-overrides", json.dumps(ho)])
+    if (sc := config.get("speculative_config")):
+        cmd.extend(["--speculative-config", json.dumps(sc)])
+    if (ea := config.get("extra_args")):
+        cmd.extend([str(a) for a in ea])
     
     # Env Vars
     env = os.environ.copy()
@@ -348,7 +397,7 @@ def main():
             menu_items.extend([str(i), name])
             
         choice = run_dialog([
-            "--clear", "--backtitle", f"AMD R9700 vLLM Launcher (GPUs: {gpu_count})",
+            "--clear", "--backtitle", f"AMD Strix Halo vLLM Launcher (GPUs: {gpu_count})",
             "--title", "Select Model",
             "--menu", "Choose a model to serve:", "20", "60", "10"
         ] + menu_items)

--- a/scripts/start_vllm_cluster.py
+++ b/scripts/start_vllm_cluster.py
@@ -299,17 +299,33 @@ def configure_and_launch_vllm(model_idx, head_ip):
 
     cmd.extend(["--mm-encoder-attn-backend", "TRITON_ATTN"])
 
-    if "Qwen3" in model_id:
-        cmd.extend(["--reasoning-parser", "qwen3"])
-            
     if str(current_seqs) != "auto":
         cmd.extend(["--max-num-seqs", str(current_seqs)])
-        
+
     if str(current_ctx) != "auto":
         cmd.extend(["--max-model-len", str(current_ctx)])
-    
+
     if trust_remote: cmd.append("--trust-remote-code")
     if use_eager: cmd.append("--enforce-eager")
+
+    # Optional structured fields (mirror of start_vllm.py).
+    config = MODEL_TABLE[model_id]
+    if (q := config.get("quantization")):
+        cmd.extend(["--quantization", q])
+    if (n := config.get("served_model_name")):
+        cmd.extend(["--served-model-name", n])
+    if (tm := config.get("tokenizer_mode")):
+        cmd.extend(["--tokenizer-mode", tm])
+    if (cf := config.get("config_format")):
+        cmd.extend(["--config-format", cf])
+    if (lf := config.get("load_format")):
+        cmd.extend(["--load-format", lf])
+    if (ho := config.get("hf_overrides")):
+        cmd.extend(["--hf-overrides", json.dumps(ho)])
+    if (sc := config.get("speculative_config")):
+        cmd.extend(["--speculative-config", json.dumps(sc)])
+    if (ea := config.get("extra_args")):
+        cmd.extend([str(a) for a in ea])
     
     print("\n" + "="*60)
     print(f" Launching VLLM Cluster on Head: {head_ip}")


### PR DESCRIPTION
## Summary

Extends `scripts/models.py` with optional `vllm serve` passthrough fields (read via `.get()` so existing entries are byte-identical), wires speculative-decoding for the new flagship 2026-Q2 models, fixes a couple of small pre-existing bugs in the launchers, and adds a `patch_strix.py` Patch_11 for GGUF mmproj wiring.

### New entries in `MODEL_TABLE`

| Entry | Notes |
|---|---|
| `mistralai/Mistral-Medium-3.5-128B` | Mistral3 dense + Pixtral. Paired with the official `mistralai/Mistral-Medium-3.5-128B-EAGLE` draft via `{"method":"eagle","num_speculative_tokens":3}` (matches the model card example). Uses the `mistral` tokenizer/config/load formats. |
| `unsloth/NVIDIA-Nemotron-3-Nano-Omni-30B-A3B-Reasoning-GGUF` | `NemotronH_Nano_Omni_Reasoning_V3` → `nano_nemotron_vl`. Mamba2/MoE hybrid with vision (Radio), audio (Parakeet), video (EVS). Uses `--reasoning-parser nemotron_v3` + `--tool-call-parser qwen3_coder` per the NVIDIA cookbook. |
| `unsloth/Qwen3.6-27B-GGUF` | `qwen3_next_mtp` with `num_speculative_tokens=2`, TP=1 only (vllm-project/vllm#41190 crashes on hybrid GDN at TP≥2). |
| `cyankiwi/Qwen3.6-27B-AWQ-INT4` | Companion safetensors path where the MTP head is intact when the GGUF copy lacks it. |

### Schema additions (all optional)

`quantization`, `served_model_name`, `tokenizer_mode`, `config_format`, `load_format`, `hf_overrides`, `speculative_config`, `attention_backend`, `extra_args`, `notes`. The `SpeculativeMethod` literal in `vllm/config/speculative.py` is the source of truth for valid `method` strings (eagle, eagle3, mtp, qwen3_next_mtp, nemotron_h_mtp, …).

### Launcher fixes (pre-existing, surfaced while wiring this PR)

- `start_vllm.py` was seeding `current_seqs = 1` regardless of the entry's `max_num_seqs`. Spec-decode is functionally disabled at `max_num_seqs=1` (no batch to amortize the draft cost), so the new entries — and any future ones — need this honored. Now: `current_seqs = int(config.get("max_num_seqs", 1))`.
- Stringly-typed enum fields (`tokenizer_mode`, `config_format`, `load_format`, `attention_backend`) are validated up front so a typo surfaces with the offending model id, not as an opaque vllm argparse error at exec time.
- TUI util default is now read from `models.GPU_UTIL` rather than a separate hardcoded `0.90`.
- `start_vllm_cluster.py` got the same optional-field passthrough and dropped the now-redundant `if "Qwen3" in model_id: --reasoning-parser qwen3` hardcode (covered by `extra_args`).
- Cosmetic: `AMD R9700 vLLM Launcher` backtitle → `AMD Strix Halo vLLM Launcher`.

### Patch_11 — GGUF mmproj wiring

`vllm/transformers_utils/gguf_utils.py` only special-cases Gemma3 in `extract_vision_config_from_gguf` and only patches HF config for `model_type in {gemma3, gemma3_text}` in `maybe_patch_hf_config_from_gguf`. As a result, an `mmproj.gguf` sibling next to a Mistral-Medium-3.5 or Nemotron-Omni GGUF is detected but the vision tower silently drops on load.

Patch_11 adds projector branches for `nemotron_v2_vl` (Radio, used by NanoNemotronVL) and `pixtral` (Mistral3), and plumbs the extracted `vision_config` into the parent for `mistral3`/`ministral3` and `nemotron_h{,_moe}`/`nemotron_v2_vl`. Idempotent — guarded by string markers in the patch like the rest of the file.

### Audio extras

Omni-modal models in vllm 0.20+ (and the registered `nano_nemotron_vl` in the current build) need `librosa`/`soundfile`/`av` at runtime. `install_deps.sh` adds the OS-level codec libraries (`libsndfile`, `flac`, `opus`, `libogg`, `libvorbis`); the `Dockerfile` installs `av/soundfile/audioread/pooch/lazy_loader/msgpack/cffi/decorator` followed by `librosa --no-deps` to skip `numba`/`llvmlite` (same workaround as `kyuz0/amd-strix-halo-voice-toolbox` README).

## Backwards compatibility

Every pre-existing `MODEL_TABLE` entry produces a byte-identical `vllm serve` command (verified offline for Llama-3.1-8B, Gemma-4-{26B,31B}, gpt-oss-{20b,120b}, Qwen3.6-35B-A3B{,-AWQ-4bit}, Qwen3.5-122B-A10B-AWQ-{4,8}bit, MiniMax-M2.7-AWQ-4bit). The new optional fields are read via `config.get(<key>, default)` so older entries that don't set them flow through unchanged.

## Test plan

- [x] `python -c "import scripts.models, ast"` syntax check on all touched Python files
- [x] Offline `vllm serve` cmd-construction dry-run for every existing entry (all byte-identical to pre-PR)
- [x] Offline cmd-construction for the four new entries (matches the official model-card examples)
- [x] `bash -n scripts/install_deps.sh`
- [x] Patch_11 applied idempotently against a checked-out vllm source tree (verified marker strings present)
- [ ] Full toolbox image rebuild — to be done by maintainer in CI; the new `dnf install` set and the post-vllm `pip install` block should not affect the existing build closures.
- [ ] Live serve smoke for each of the four new entries — pending follow-up benchmarks PR.

## References

- mistralai/Mistral-Medium-3.5-128B (HF, 2026-04-29)
- mistralai/Mistral-Medium-3.5-128B-EAGLE (HF, 2026-04-27) — `method:"eagle"`, `num_speculative_tokens:3` per the official card
- unsloth/NVIDIA-Nemotron-3-Nano-Omni-30B-A3B-Reasoning-GGUF (HF, 2026-04-28)
- unsloth/Qwen3.6-27B-GGUF (HF, 2026-04-22) — `num_speculative_tokens:2` per the Unsloth vLLM example
- vllm-project/vllm#41190 (TP=2 + qwen3_next_mtp on hybrid GDN, open)
- vllm-project/vllm#39010 (HIP graph hang on Mistral / gfx1151, open — `--enforce-eager` is the workaround)