### PR TITLE
Add Ubuntu 26.04 Docker Engine path for Strix Halo vLLM

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,10 +135,9 @@ Docker-native path in [docs/ubuntu-docker.md](docs/ubuntu-docker.md).
 ```
 
 This Ubuntu path is separate from Fedora Toolbx. It does not use Podman,
-Distrobox, Fedora Toolbx, Ubuntu toolbox, or LXC. It passes `/dev/kfd`,
-`/dev/dri`, the `video` and `render` groups, `seccomp=unconfined`, `ipc=host`,
-and host networking to Docker, and mounts Hugging Face and vLLM caches from the
-host.
+Distrobox, Fedora Toolbx, Ubuntu toolbox, or LXC. It uses Docker Engine only;
+see the Ubuntu Docker guide for runtime flags, prerequisites, and conservative
+validation notes.
 
 Start with the conservative smoke test before launching vLLM:
 
@@ -148,7 +147,8 @@ Start with the conservative smoke test before launching vLLM:
 
 On Ubuntu, GRUB is updated with `sudo update-grub`, not
 `sudo grub2-mkconfig -o /boot/grub2/grub.cfg`. Host boot parameter changes are
-not made by this repository's scripts.
+manual, risk-bearing host state changes and are not made by this repository's
+scripts.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ This is a hobby project maintained in my spare time. If you find these toolboxes
 * [Tested Models (Benchmarks)](#tested-models-benchmarks)
 * [1) Toolbx vs Docker/Podman](#1-toolbx-vs-dockerpodman)
 * [2) Quickstart — Fedora Toolbx](#2-quickstart--fedora-toolbx)
-* [3) Quickstart — Ubuntu (Distrobox)](#3-quickstart--ubuntu-distrobox)
+* [3) Quickstart — Ubuntu Docker Engine](#3-quickstart--ubuntu-docker-engine)
 * [4) Testing the API](#4-testing-the-api)
 * [5) Use a Web UI for Chatting](#5-use-a-web-ui-for-chatting)
 * [6) Host Configuration](#6-host-configuration)
@@ -125,27 +125,30 @@ start-vllm
 
 ---
 
-## 3) Quickstart — Ubuntu (Distrobox)
+## 3) Quickstart — Ubuntu Docker Engine
 
-Ubuntu’s toolbox package still breaks GPU access, so use Distrobox instead:
-
-```bash
-distrobox create -n vllm \
-  --image docker.io/kyuz0/vllm-therock-gfx1151:stable \
-  --additional-flags "--device /dev/kfd --device /dev/dri --group-add video --group-add render --security-opt seccomp=unconfined"
-
-distrobox enter vllm
-```
-
-> **Verification:** Run `rocm-smi` to check GPU status.
-
-### Serving a Model (Easiest Way)
-
-The toolbox includes a TUI wizard called **`start-vllm`** which includes pre-configured models and handles the launch flags for you. This is the easiest way to get started.
+For Ubuntu 26.04 hosts that should use Docker Engine only, follow the
+Docker-native path in [docs/ubuntu-docker.md](docs/ubuntu-docker.md).
 
 ```bash
-start-vllm
+./scripts/run-ubuntu-docker-vllm.sh shell
 ```
+
+This Ubuntu path is separate from Fedora Toolbx. It does not use Podman,
+Distrobox, Fedora Toolbx, Ubuntu toolbox, or LXC. It passes `/dev/kfd`,
+`/dev/dri`, the `video` and `render` groups, `seccomp=unconfined`, `ipc=host`,
+and host networking to Docker, and mounts Hugging Face and vLLM caches from the
+host.
+
+Start with the conservative smoke test before launching vLLM:
+
+```bash
+./scripts/run-ubuntu-docker-vllm.sh smoke
+```
+
+On Ubuntu, GRUB is updated with `sudo update-grub`, not
+`sudo grub2-mkconfig -o /boot/grub2/grub.cfg`. Host boot parameter changes are
+not made by this repository's scripts.
 
 ---
 

--- a/docs/ubuntu-docker.md
+++ b/docs/ubuntu-docker.md
@@ -140,15 +140,36 @@ Only after the smoke test passes should you launch vLLM:
 start-vllm
 ```
 
-For a direct server launch instead of the TUI, pass the command after `--`:
+For a direct server launch instead of the TUI, pass the command after `--`.
+Port `8000` may already be occupied by another service or legacy container; in
+one validation it was occupied by `legacy-printer`. Check before launching, or
+use another port:
+
+```bash
+ss -ltnp | grep ':8000'
+lsof -iTCP:8000 -sTCP:LISTEN
+```
+
+The first conservative API validation model was
+`Qwen/Qwen2.5-7B-Instruct`. This is a small validation target for proving the
+Docker/vLLM API path, not the final performance target and not proof that
+larger models are validated.
 
 ```bash
 ./scripts/run-ubuntu-docker-vllm.sh run -- \
   python -m vllm.entrypoints.openai.api_server \
     --host 0.0.0.0 \
-    --port 8000 \
-    --model meta-llama/Meta-Llama-3.1-8B-Instruct
+    --port 8010 \
+    --model Qwen/Qwen2.5-7B-Instruct \
+    --dtype bfloat16 \
+    --max-model-len 8192 \
+    --gpu-memory-utilization 0.60 \
+    --enforce-eager
 ```
+
+Do not make this direct-launch example depend on `VLLM_ATTENTION_BACKEND`; the
+validated `docker.io/kyuz0/vllm-therock-gfx1151:stable` build did not recognize
+that environment variable.
 
 ## Helper Script
 
@@ -165,14 +186,28 @@ Ubuntu toolbox, LXC, host ROCm tools, package installation, or `sudo`.
 
 ## API Check After vLLM Starts
 
-Once vLLM is listening on port 8000:
+Ubuntu 26.04 validation on kernel `7.0.0-15-generic` with
+`docker.io/kyuz0/vllm-therock-gfx1151:stable` launched
+`Qwen/Qwen2.5-7B-Instruct` successfully on port `8010` using:
+
+- `--dtype bfloat16`
+- `--max-model-len 8192`
+- `--gpu-memory-utilization 0.60`
+- `--enforce-eager`
+
+During startup, vLLM reported that model loading took `14.34 GiB` of memory and
+reported `52.87 GiB` of available KV cache memory.
+
+Once vLLM is listening, query the port selected at launch:
 
 ```bash
-curl -s http://localhost:8000/v1/models
+curl -s http://localhost:8010/v1/models
 ```
 
 Then send a small OpenAI-compatible request using the model ID returned by the
-server.
+server. In the validation above, `/v1/models` returned HTTP `200` and listed
+`Qwen/Qwen2.5-7B-Instruct`; `/v1/chat/completions` returned a valid assistant
+response.
 
 ## Fedora Toolbx Is Separate
 

--- a/docs/ubuntu-docker.md
+++ b/docs/ubuntu-docker.md
@@ -224,6 +224,33 @@ server. In the validation above, `/v1/models` returned HTTP `200` and listed
 `Qwen/Qwen2.5-7B-Instruct`; `/v1/chat/completions` returned a valid assistant
 response.
 
+### Authenticated Conservative API Validation
+
+After Hugging Face authentication with `hf auth login`, the same Ubuntu Docker
+vLLM validation was rerun against the cached model data. The authenticated run
+used `docker.io/kyuz0/vllm-therock-gfx1151:stable` with
+`Qwen/Qwen2.5-7B-Instruct` on port `8010` and the same conservative flags:
+
+- `--dtype bfloat16`
+- `--max-model-len 8192`
+- `--gpu-memory-utilization 0.60`
+- `--enforce-eager`
+
+In that authenticated run, `/v1/models` returned HTTP `200`.
+`/v1/chat/completions` returned HTTP `200` and produced exactly:
+
+```text
+authenticated Docker vLLM validation passed
+```
+
+The rerun did not show the previous unauthenticated Hugging Face warning. vLLM
+reported that model loading took `14.34 GiB` and that available KV cache memory
+was `52.87 GiB`. While vLLM was running, host memory showed about `46 GiB`
+available.
+
+This validates only the conservative authenticated Docker/vLLM API path above.
+It is not larger-model validation and is not performance validation.
+
 ## Fedora Toolbx Is Separate
 
 The main README still documents Fedora Toolbx and RDMA-oriented workflows. This

--- a/docs/ubuntu-docker.md
+++ b/docs/ubuntu-docker.md
@@ -102,6 +102,38 @@ The smoke test checks device nodes, ROCm visibility, Python package imports,
 PyTorch ROCm availability, and basic GPU discovery before any vLLM server is
 started.
 
+## Memory Exposure Observations
+
+Ubuntu 26.04 validation on kernel `7.0.0-15-generic` used the
+`docker.io/kyuz0/vllm-therock-gfx1151:stable` image. The Docker ROCm/vLLM smoke
+test passed on that host.
+
+The host kernel command line included:
+
+```text
+iommu=pt ttm.pages_limit=32505856 ttm.page_pool_size=32505856 amdgpu.gttsize=126976
+```
+
+With that configuration, `dmesg` reported:
+
+```text
+126976M of GTT memory ready.
+```
+
+Treat this as kernel GTT readiness, not as proof that a single userspace
+allocation can consume all of that memory. In the same validation, PyTorch still
+reported `reported_total_memory_mib` around `62890`, so PyTorch's reported total
+memory should not be presented as the whole usable GTT story either.
+
+High-memory allocation tests must be run with other GPU/model containers
+stopped. With existing Strix model containers still running, a 48 GiB PyTorch
+allocation caused global OOM or hung-system behavior. After stopping
+`qwen3-coder` and `qwen3-6` and disabling their restart policy, single PyTorch
+`uint8` allocations of 40 GiB, 44 GiB, and 48 GiB passed cleanly.
+
+The current proven clean single-allocation size from this validation is 48 GiB.
+Do not claim that 126 GiB usable allocation has been proven from these results.
+
 Only after the smoke test passes should you launch vLLM:
 
 ```bash

--- a/docs/ubuntu-docker.md
+++ b/docs/ubuntu-docker.md
@@ -251,6 +251,38 @@ available.
 This validates only the conservative authenticated Docker/vLLM API path above.
 It is not larger-model validation and is not performance validation.
 
+### Larger-Model Conservative API Validation
+
+A later Ubuntu Docker validation used the larger repo-listed model
+`google/gemma-4-26B-A4B-it` with
+`docker.io/kyuz0/vllm-therock-gfx1151:stable` on port `8010`.
+
+This was a separate validation from the earlier
+`Qwen/Qwen2.5-7B-Instruct` checks. It used the same conservative serving
+flags:
+
+- `--dtype bfloat16`
+- `--max-model-len 8192`
+- `--gpu-memory-utilization 0.60`
+- `--enforce-eager`
+
+During model loading, `/health` initially returned connection refused because
+the API port was not bound until model load completed. Treat this as expected
+startup behavior for curl checks: wait until vLLM has finished loading and the
+server is actually listening before using `/health`, `/v1/models`, or
+`/v1/chat/completions` as validation signals.
+
+After startup completed, `/v1/chat/completions` returned a valid response:
+
+```text
+larger conservative vLLM validation passed
+```
+
+This validates only conservative serving for `google/gemma-4-26B-A4B-it`
+through the Ubuntu Docker path above. It does not validate maximum context,
+high concurrency, AITER, or 120B-class models, and it should not be presented as
+a performance result.
+
 ## Fedora Toolbx Is Separate
 
 The main README still documents Fedora Toolbx and RDMA-oriented workflows. This

--- a/docs/ubuntu-docker.md
+++ b/docs/ubuntu-docker.md
@@ -1,0 +1,149 @@
+# Ubuntu 26.04 Docker Engine Path for Strix Halo
+
+This path is for Ubuntu hosts using Docker Engine directly. It does not use
+Podman, Distrobox, Fedora Toolbx, Ubuntu toolbox, or LXC.
+
+The container image is the same Strix Halo `gfx1151` image used elsewhere in
+this repository:
+
+```bash
+docker.io/kyuz0/vllm-therock-gfx1151:stable
+```
+
+Use `:stable` first. Use `:latest` only when you intentionally want to test a
+newer image that may have upstream regressions.
+
+## Tested Host Shape
+
+This document targets Ubuntu 26.04 LTS on AMD Strix Halo / Radeon 8050S or
+8060S class hardware, with Docker Engine already installed and active.
+
+Known-good host expectations:
+
+- `/dev/kfd` exists and is accessible to the `render` group.
+- `/dev/dri/card*` exists and is accessible to the `video` group.
+- `/dev/dri/renderD*` exists and is accessible to the `render` group.
+- The user running Docker is already in `docker`, `video`, and `render`.
+- ROCm tools do not need to be installed on the Ubuntu host. ROCm is validated
+  inside the container.
+
+## Host Kernel Notes
+
+For Ubuntu, update GRUB with `update-grub`, not `grub2-mkconfig`.
+
+The upstream Strix Halo guidance commonly uses:
+
+```text
+iommu=pt amdgpu.gttsize=126976 ttm.pages_limit=32505856
+```
+
+On Ubuntu, that means editing `/etc/default/grub`, then applying with:
+
+```bash
+sudo update-grub
+sudo reboot
+```
+
+Do not run those commands from this repository's scripts. They are host state
+changes and should be handled manually by the system owner.
+
+If the current kernel command line already contains `iommu=pt` and
+`ttm.pages_limit=32505856` but does not contain `amdgpu.gttsize=126976`, treat
+that as a host configuration difference to review before large-model testing.
+If it also contains `ttm.page_pool_size=32505856`, note that this differs from
+the upstream README recommendation above and should be evaluated separately.
+
+## Required Docker Runtime Flags
+
+The Docker container needs direct access to the AMD GPU devices and relaxed
+runtime isolation for ROCm/vLLM:
+
+- `--device /dev/kfd`
+- `--device /dev/dri`
+- `--group-add video`
+- `--group-add render`
+- `--security-opt seccomp=unconfined`
+- `--ipc=host`
+- `--network=host`
+
+The helper script in this repo uses those flags by default.
+
+## Cache Mounts
+
+Keep model weights and compiled kernels on the host so they survive container
+recreation:
+
+- Hugging Face cache: `~/.cache/huggingface` mounted to
+  `/root/.cache/huggingface`
+- vLLM cache: `~/.cache/vllm` mounted to `/root/.cache/vllm`
+
+Override them when needed:
+
+```bash
+HF_HOME=/data/hf-cache VLLM_CACHE_ROOT=/data/vllm-cache \
+  ./scripts/run-ubuntu-docker-vllm.sh shell
+```
+
+## First Run: Conservative Validation
+
+Start with an interactive shell:
+
+```bash
+./scripts/run-ubuntu-docker-vllm.sh shell
+```
+
+Inside the container, run the smoke test:
+
+```bash
+/workspace/scripts/smoke-test-ubuntu-docker-vllm.sh
+```
+
+The smoke test checks device nodes, ROCm visibility, Python package imports,
+PyTorch ROCm availability, and basic GPU discovery before any vLLM server is
+started.
+
+Only after the smoke test passes should you launch vLLM:
+
+```bash
+start-vllm
+```
+
+For a direct server launch instead of the TUI, pass the command after `--`:
+
+```bash
+./scripts/run-ubuntu-docker-vllm.sh run -- \
+  python -m vllm.entrypoints.openai.api_server \
+    --host 0.0.0.0 \
+    --port 8000 \
+    --model meta-llama/Meta-Llama-3.1-8B-Instruct
+```
+
+## Helper Script
+
+The Docker runner is repo-local:
+
+```bash
+./scripts/run-ubuntu-docker-vllm.sh shell
+./scripts/run-ubuntu-docker-vllm.sh smoke
+./scripts/run-ubuntu-docker-vllm.sh run -- start-vllm
+```
+
+It intentionally does not use or require Podman, Distrobox, Fedora Toolbx,
+Ubuntu toolbox, LXC, host ROCm tools, package installation, or `sudo`.
+
+## API Check After vLLM Starts
+
+Once vLLM is listening on port 8000:
+
+```bash
+curl -s http://localhost:8000/v1/models
+```
+
+Then send a small OpenAI-compatible request using the model ID returned by the
+server.
+
+## Fedora Toolbx Is Separate
+
+The main README still documents Fedora Toolbx and RDMA-oriented workflows. This
+Ubuntu path is Docker-native and should be used on Ubuntu hosts where the goal
+is to run Docker Engine directly without Podman, Distrobox, toolbox, or LXC.

--- a/docs/ubuntu-docker.md
+++ b/docs/ubuntu-docker.md
@@ -84,6 +84,21 @@ HF_HOME=/data/hf-cache VLLM_CACHE_ROOT=/data/vllm-cache \
   ./scripts/run-ubuntu-docker-vllm.sh shell
 ```
 
+## Hugging Face Authentication
+
+Do not paste Hugging Face tokens into docs, issues, pull requests, or chat.
+Inside this image, `huggingface-cli login` is deprecated. Use:
+
+```bash
+hf auth login
+hf auth whoami
+```
+
+The Docker runner mounts the host Hugging Face cache into
+`/root/.cache/huggingface`, so authentication persists for future runs. The git
+credential helper warning can be ignored for model downloads; it matters only
+for Git-based Hugging Face pushes.
+
 ## First Run: Conservative Validation
 
 Start with an interactive shell:

--- a/docs/ubuntu-docker.md
+++ b/docs/ubuntu-docker.md
@@ -13,17 +13,45 @@ docker.io/kyuz0/vllm-therock-gfx1151:stable
 Use `:stable` first. Use `:latest` only when you intentionally want to test a
 newer image that may have upstream regressions.
 
-## Tested Host Shape
+## Tested Environment
 
-This document targets Ubuntu 26.04 LTS on AMD Strix Halo / Radeon 8050S or
-8060S class hardware, with Docker Engine already installed and active.
+This path has been observed working on:
 
-Known-good host expectations:
+- Ubuntu 26.04 LTS
+- Kernel `7.0.0-15-generic`
+- AMD Strix Halo / Ryzen AI Max+ 395 / Radeon 8060S-class hardware
+- Docker Engine
+- `docker.io/kyuz0/vllm-therock-gfx1151:stable`
 
-- `/dev/kfd` exists and is accessible to the `render` group.
-- `/dev/dri/card*` exists and is accessible to the `video` group.
-- `/dev/dri/renderD*` exists and is accessible to the `render` group.
-- The user running Docker is already in `docker`, `video`, and `render`.
+Conservative observed validation covered:
+
+- `Qwen/Qwen2.5-7B-Instruct`
+- `google/gemma-4-26B-A4B-it`
+
+Treat this as observed validation for one Ubuntu 26.04 Strix Halo setup, not a
+guarantee that every Ubuntu 26.04 Strix Halo system will behave identically.
+
+## Prerequisite Checklist
+
+Before running the container, check the host:
+
+```bash
+docker --version
+docker compose version
+groups
+ls -l /dev/kfd /dev/dri
+cat /proc/cmdline
+```
+
+Expected conditions:
+
+- Docker Engine is installed and active.
+- The user can run Docker.
+- `/dev/kfd` exists.
+- `/dev/dri` exists.
+- The user has `video` and `render` group access.
+- Other GPU or model-serving workloads are stopped before high-memory
+  validation.
 - ROCm tools do not need to be installed on the Ubuntu host. ROCm is validated
   inside the container.
 
@@ -46,6 +74,9 @@ sudo reboot
 
 Do not run those commands from this repository's scripts. They are host state
 changes and should be handled manually by the system owner.
+
+Incorrect kernel parameters can affect boot or GPU memory behavior. Back up
+`/etc/default/grub` and keep a recovery path before changing them.
 
 If the current kernel command line already contains `iommu=pt` and
 `ttm.pages_limit=32505856` but does not contain `amdgpu.gttsize=126976`, treat
@@ -140,11 +171,11 @@ allocation can consume all of that memory. In the same validation, PyTorch still
 reported `reported_total_memory_mib` around `62890`, so PyTorch's reported total
 memory should not be presented as the whole usable GTT story either.
 
-High-memory allocation tests must be run with other GPU/model containers
-stopped. With existing Strix model containers still running, a 48 GiB PyTorch
-allocation caused global OOM or hung-system behavior. After stopping
-`qwen3-coder` and `qwen3-6` and disabling their restart policy, single PyTorch
-`uint8` allocations of 40 GiB, 44 GiB, and 48 GiB passed cleanly.
+High-memory allocation tests should be run only after stopping other GPU or
+model-serving workloads. In the observed validation, a 48 GiB PyTorch
+allocation was not clean while other model-serving workloads were active. After
+those workloads were stopped, single PyTorch `uint8` allocations of 40 GiB,
+44 GiB, and 48 GiB passed cleanly.
 
 The current proven clean single-allocation size from this validation is 48 GiB.
 Do not claim that 126 GiB usable allocation has been proven from these results.
@@ -156,8 +187,7 @@ start-vllm
 ```
 
 For a direct server launch instead of the TUI, pass the command after `--`.
-Port `8000` may already be occupied by another service or legacy container; in
-one validation it was occupied by `legacy-printer`. Check before launching, or
+Port `8000` may already be occupied on some hosts. Check before launching, or
 use another port:
 
 ```bash
@@ -191,10 +221,13 @@ that environment variable.
 The Docker runner is repo-local:
 
 ```bash
+./scripts/run-ubuntu-docker-vllm.sh print
 ./scripts/run-ubuntu-docker-vllm.sh shell
 ./scripts/run-ubuntu-docker-vllm.sh smoke
 ./scripts/run-ubuntu-docker-vllm.sh run -- start-vllm
 ```
+
+Use `print` to inspect the Docker command before running the container.
 
 It intentionally does not use or require Podman, Distrobox, Fedora Toolbx,
 Ubuntu toolbox, LXC, host ROCm tools, package installation, or `sudo`.
@@ -279,9 +312,20 @@ larger conservative vLLM validation passed
 ```
 
 This validates only conservative serving for `google/gemma-4-26B-A4B-it`
-through the Ubuntu Docker path above. It does not validate maximum context,
-high concurrency, AITER, or 120B-class models, and it should not be presented as
-a performance result.
+through the Ubuntu Docker path above, and it should not be presented as a
+performance result.
+
+## Known Limitations / Not Validated
+
+This Ubuntu Docker path has not validated:
+
+- 120B-class models
+- Maximum context length
+- High concurrency
+- Production service hardening
+- RDMA/RoCE clustering
+- Tensor parallelism across nodes
+- AITER performance mode
 
 ## Fedora Toolbx Is Separate
 

--- a/scripts/run-ubuntu-docker-vllm.sh
+++ b/scripts/run-ubuntu-docker-vllm.sh
@@ -1,0 +1,137 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+IMAGE_REPO="${IMAGE_REPO:-docker.io/kyuz0/vllm-therock-gfx1151}"
+IMAGE_TAG="${IMAGE_TAG:-stable}"
+CONTAINER_NAME="${CONTAINER_NAME:-vllm-strix-halo}"
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+HF_HOME="${HF_HOME:-$HOME/.cache/huggingface}"
+VLLM_CACHE_ROOT="${VLLM_CACHE_ROOT:-$HOME/.cache/vllm}"
+WORKSPACE_MOUNT="${WORKSPACE_MOUNT:-$REPO_ROOT}"
+
+usage() {
+    cat <<EOF
+Usage:
+  $0 shell
+  $0 smoke
+  $0 run -- <command> [args...]
+  $0 print -- <command> [args...]
+
+Environment:
+  IMAGE_REPO          default: docker.io/kyuz0/vllm-therock-gfx1151
+  IMAGE_TAG           default: stable
+  CONTAINER_NAME      default: vllm-strix-halo
+  HF_HOME             default: \$HOME/.cache/huggingface
+  VLLM_CACHE_ROOT     default: \$HOME/.cache/vllm
+  WORKSPACE_MOUNT     default: repository root
+
+This script uses Docker Engine only. It does not use Podman, Distrobox,
+toolbox, LXC, sudo, host ROCm tools, or package installation.
+EOF
+}
+
+require_docker() {
+    if ! command -v docker >/dev/null 2>&1; then
+        echo "Error: docker is not available in PATH." >&2
+        exit 1
+    fi
+}
+
+require_device() {
+    local path="$1"
+    if [[ ! -e "$path" ]]; then
+        echo "Error: required device is missing: $path" >&2
+        exit 1
+    fi
+}
+
+build_docker_args() {
+    local image="${IMAGE_REPO}:${IMAGE_TAG}"
+
+    DOCKER_ARGS=(
+        run
+        --rm
+        -it
+        --name "$CONTAINER_NAME"
+        --device /dev/kfd
+        --device /dev/dri
+        --group-add video
+        --group-add render
+        --security-opt seccomp=unconfined
+        --ipc=host
+        --network=host
+        -e HF_HOME=/root/.cache/huggingface
+        -e HUGGINGFACE_HUB_CACHE=/root/.cache/huggingface/hub
+        -e TRANSFORMERS_CACHE=/root/.cache/huggingface/transformers
+        -e VLLM_CACHE_ROOT=/root/.cache/vllm
+        -v "${HF_HOME}:/root/.cache/huggingface"
+        -v "${VLLM_CACHE_ROOT}:/root/.cache/vllm"
+        -v "${WORKSPACE_MOUNT}:/workspace:ro"
+        -w /workspace
+        "$image"
+    )
+}
+
+print_command() {
+    printf 'docker'
+    printf ' %q' "${DOCKER_ARGS[@]}"
+    printf ' %q' "$@"
+    printf '\n'
+}
+
+main() {
+    local mode="${1:-}"
+    shift || true
+
+    case "$mode" in
+        shell|smoke|run|print)
+            ;;
+        -h|--help|help|"")
+            usage
+            exit 0
+            ;;
+        *)
+            echo "Error: unknown mode: $mode" >&2
+            usage >&2
+            exit 1
+            ;;
+    esac
+
+    require_docker
+    require_device /dev/kfd
+    require_device /dev/dri
+
+    mkdir -p "$HF_HOME" "$VLLM_CACHE_ROOT"
+    build_docker_args
+
+    case "$mode" in
+        shell)
+            docker "${DOCKER_ARGS[@]}" bash -l
+            ;;
+        smoke)
+            docker "${DOCKER_ARGS[@]}" /workspace/scripts/smoke-test-ubuntu-docker-vllm.sh
+            ;;
+        run)
+            if [[ "${1:-}" == "--" ]]; then
+                shift
+            fi
+            if [[ "$#" -eq 0 ]]; then
+                echo "Error: run mode requires a command after --." >&2
+                exit 1
+            fi
+            docker "${DOCKER_ARGS[@]}" "$@"
+            ;;
+        print)
+            if [[ "${1:-}" == "--" ]]; then
+                shift
+            fi
+            if [[ "$#" -eq 0 ]]; then
+                set -- bash -l
+            fi
+            print_command "$@"
+            ;;
+    esac
+}
+
+main "$@"

--- a/scripts/smoke-test-ubuntu-docker-vllm.sh
+++ b/scripts/smoke-test-ubuntu-docker-vllm.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "== Device nodes =="
+test -e /dev/kfd
+test -d /dev/dri
+ls -l /dev/kfd /dev/dri || true
+
+echo
+echo "== Groups =="
+id
+
+echo
+echo "== ROCm tools =="
+if command -v rocm-smi >/dev/null 2>&1; then
+    rocm-smi || true
+else
+    echo "rocm-smi is not present in this image or not on PATH."
+fi
+
+if command -v rocminfo >/dev/null 2>&1; then
+    rocminfo | sed -n '1,120p'
+else
+    echo "rocminfo is not present in this image or not on PATH."
+fi
+
+echo
+echo "== Python, PyTorch, and vLLM =="
+python - <<'PY'
+import importlib
+import os
+import sys
+
+print("python:", sys.version.replace("\n", " "))
+print("HF_HOME:", os.environ.get("HF_HOME"))
+print("VLLM_CACHE_ROOT:", os.environ.get("VLLM_CACHE_ROOT"))
+
+for module_name in ("torch", "vllm"):
+    module = importlib.import_module(module_name)
+    print(f"{module_name}:", getattr(module, "__version__", "unknown"))
+
+import torch
+
+print("torch.version.hip:", torch.version.hip)
+print("torch.cuda.is_available:", torch.cuda.is_available())
+print("torch.cuda.device_count:", torch.cuda.device_count())
+
+if not torch.cuda.is_available():
+    raise SystemExit("PyTorch ROCm backend did not report an available GPU.")
+
+for index in range(torch.cuda.device_count()):
+    props = torch.cuda.get_device_properties(index)
+    print(
+        f"device[{index}]: name={props.name}, "
+        f"total_memory={props.total_memory // (1024 ** 2)} MiB"
+    )
+
+x = torch.ones((1024,), device="cuda")
+print("cuda_tensor_sum:", float(x.sum().item()))
+PY
+
+echo
+echo "Smoke test passed. Start vLLM only after these checks are clean."


### PR DESCRIPTION
Adds a Docker Engine-only Ubuntu 26.04 path for Strix Halo, including a Docker runner, smoke test, conservative validation notes, Hugging Face auth guidance, memory exposure observations, and known limitations.

This path is separate from Fedora Toolbx/Distrobox and does not use Podman, Distrobox, Toolbx, Ubuntu toolbox, or LXC.

Validated conservatively on one Ubuntu 26.04 Strix Halo setup with:
- docker.io/kyuz0/vllm-therock-gfx1151:stable
- Qwen/Qwen2.5-7B-Instruct
- google/gemma-4-26B-A4B-it
- Docker Engine only
- /dev/kfd and /dev/dri passthrough
- video/render group access
- seccomp=unconfined, ipc=host, host networking

The documentation explicitly does not claim validation for max context, high concurrency, AITER performance mode, RDMA/RoCE clustering, tensor parallelism across nodes, production service hardening, or 120B-class models.