### PR TITLE
build: scope `|| true` to strip in venv-cleanup steps

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,7 @@ RUN python -m pip install --upgrade pip wheel packaging "setuptools<80.0.0"
 RUN python -m pip install \
   --index-url https://rocm.nightlies.amd.com/v2-staging/gfx1151/ \
   --pre torch torchaudio torchvision && \
-  find /opt/venv -type f -name "*.so" -exec strip -s {} + 2>/dev/null || true && \
+  (find /opt/venv -type f -name "*.so" -exec strip -s {} + 2>/dev/null || true) && \
   rm -rf /root/.cache/pip
 
 WORKDIR /opt
@@ -57,7 +57,7 @@ RUN git clone https://github.com/ROCm/flash-attention.git && \
     python -c "import re; f=open('setup.py','r'); t=f.read(); f.close(); t=re.sub(r'subprocess\.run\([\s\S]*?third_party/aiter[\s\S]*?check=True,\s*\)', 'pass # patched', t); f=open('setup.py','w'); f.write(t)" && \
     pip install --no-build-isolation --no-deps . && \
     cd /opt && rm -rf /opt/flash-attention /opt/patch_aiter_headers.py && \
-    find /opt/venv -type f -name "*.so" -exec strip -s {} + 2>/dev/null || true && \
+    (find /opt/venv -type f -name "*.so" -exec strip -s {} + 2>/dev/null || true) && \
     rm -rf /root/.cache/pip
 
 # Fix Fedora lib vs lib64 split: setup.py install writes to lib/, pip to lib64/.
@@ -109,7 +109,7 @@ RUN export HIP_DEVICE_LIB_PATH=$(find /opt/rocm -type d -name bitcode -print -qu
   python -m pip wheel --no-build-isolation --no-deps -w /tmp/dist -v . && \
   python -m pip install /tmp/dist/*.whl && \
   rm -rf /tmp/dist && \
-  find /opt/venv -type f -name "*.so" -exec strip -s {} + 2>/dev/null || true && \
+  (find /opt/venv -type f -name "*.so" -exec strip -s {} + 2>/dev/null || true) && \
   rm -rf /root/.cache/pip
 
 RUN python -m pip install ray
@@ -133,12 +133,12 @@ RUN cmake -S . \
   && \
   make -j$(nproc) && \
   python -m pip install --no-cache-dir . --no-build-isolation --no-deps && \
-  find /opt/venv -type f -name "*.so" -exec strip -s {} + 2>/dev/null || true && \
+  (find /opt/venv -type f -name "*.so" -exec strip -s {} + 2>/dev/null || true) && \
   rm -rf /root/.cache/pip
 
 # 8. Final Cleanup & Runtime
 WORKDIR /opt
-RUN find /opt/venv -type f -name "*.so" -exec strip -s {} + 2>/dev/null || true && \
+RUN (find /opt/venv -type f -name "*.so" -exec strip -s {} + 2>/dev/null || true) && \
   find /opt/venv -type d -name "__pycache__" -prune -exec rm -rf {} + && \
   rm -rf /root/.cache/pip || true && \
   dnf clean all && rm -rf /var/cache/dnf/*


### PR DESCRIPTION
## What

Wraps the `strip` cleanup in parens at five `RUN` steps so the trailing `|| true` applies only to `strip`, not the whole `&&` chain.

## Why

The recurring cleanup line sits at the end of long `&&` build chains:

```dockerfile
... && pip wheel ... && pip install ... && \
  find /opt/venv ... -exec strip -s {} + 2>/dev/null || true && \
  rm -rf /root/.cache/pip
```

Because `&&` and `||` are equal precedence and left-associative, the trailing `|| true` masks failure of the **entire** preceding chain — not just `strip`. A failed `pip wheel`, `pip install`, `cmake`, or `make` is swallowed and the `RUN` exits 0, producing a **green image with the build artifact missing**. (This bit us: a failed vLLM wheel build produced an image with no vLLM in it.)

## Fix

```dockerfile
  (find /opt/venv ... -exec strip -s {} + 2>/dev/null || true) && \
```

`strip`'s own exit stays tolerated, so behaviour is unchanged in the normal case; only genuine build-command failures now propagate.

## Testing

Verified `strip -s` exits 0 on all 392 ELF `.so` in a built image (the ROCm-SDK `.gnu.build.attributes` messages are non-fatal warnings). Also confirmed a non-ELF `.so` makes the batched `find ... -exec strip {} +` exit non-zero and that `2>/dev/null` suppresses only the messages, not the exit code — so real failures still surface. Five occurrences scoped; the `cp`/`rm` `|| true` uses elsewhere are already correctly scoped by left-associativity and left unchanged.