### PR TITLE
patch_strix: make spinloop.cpp clang-compatible (mwaitxintrin → x86intrin)

### DIFF
--- a/scripts/patch_strix.py
+++ b/scripts/patch_strix.py
@@ -6,6 +6,24 @@ from pathlib import Path
 def patch_vllm():
     print("Applying Strix Halo patches to vLLM (ai-notes modernization)...")
 
+    # Patch 0: csrc/spinloop.cpp (clang-compatible mwaitx include)
+    # spinloop.cpp includes <mwaitxintrin.h> directly. ROCm clang rejects that
+    # with a hard #error ("Never use <mwaitxintrin.h> directly; include
+    # <x86intrin.h> instead."). GCC tolerates it, so vLLM upstream CI never sees
+    # the break — but this toolbox builds vLLM with CC/CXX=ROCm clang (for ABI
+    # alignment with PyTorch), so the spinloop target fails to compile.
+    # <x86intrin.h> is the umbrella header accepted by both compilers and still
+    # exposes the MONITORX/MWAITX intrinsics. Guarded so it no-ops once vLLM
+    # fixes it upstream or removes the file.
+    p_spinloop = Path('csrc/spinloop.cpp')
+    if p_spinloop.exists():
+        txt = p_spinloop.read_text()
+        if '#include <mwaitxintrin.h>' in txt:
+            txt = txt.replace('#include <mwaitxintrin.h>',
+                              '#include <x86intrin.h>')
+            p_spinloop.write_text(txt)
+            print(" -> Patched csrc/spinloop.cpp (mwaitxintrin.h -> x86intrin.h for clang)")
+
     # Patch 1: vllm/platforms/__init__.py (amdsmi monkey patch — PROVEN working for 5 months)
     # Comment out real amdsmi imports and replace with pass stubs.
     # The actual amdsmi library doesn't work on Strix Halo APUs in containers.


### PR DESCRIPTION
## What

Adds a guarded source patch (`Patch 0`) to `patch_strix.py` that rewrites `#include <mwaitxintrin.h>` → `#include <x86intrin.h>` in vLLM's `csrc/spinloop.cpp`.

## Why

ROCm clang rejects a direct include of `<mwaitxintrin.h>` with a hard error:

```
/opt/rocm/lib/llvm/lib/clang/.../mwaitxintrin.h:11:2: error: "Never use <mwaitxintrin.h> directly; include <x86intrin.h> instead."
```

GCC tolerates the direct include, so vLLM upstream CI (which builds with GCC) never sees it. This toolbox builds vLLM with `CC`/`CXX` set to ROCm clang (the "CRITICAL FIX FOR SEGFAULT" ABI-alignment block in the Dockerfile), so the `spinloop` target fails to compile and the whole vLLM wheel build dies.

`<x86intrin.h>` is the umbrella header accepted by both GCC and clang, and it still exposes the MONITORX/MWAITX intrinsics `spinloop.cpp` uses (the build already passes `-mmwaitx`).

## Placement

Slots in as `Patch 0` alongside the existing numbered vLLM source patches. Guarded (`if '#include <mwaitxintrin.h>' in txt`), so it no-ops once vLLM fixes it upstream or removes the file.

## Upstream

Reported the underlying issue to vLLM with the suggested one-line fix: vllm-project/vllm#45515. If it lands upstream this patch becomes dead code and can be dropped (it's guarded, so it no-ops automatically).

## Testing

Built the full image against vLLM `eb28452b1` and served a model end-to-end on gfx1151 (Framework Desktop, Ryzen AI Max+ 395).