### PR TITLE
Greenfield Ubuntu + official-ROCm base for gfx1151 (off the nightly treadmill)

### DIFF
--- a/.github/workflows/build-ubuntu-nightly.yml
+++ b/.github/workflows/build-ubuntu-nightly.yml
@@ -149,8 +149,10 @@ jobs:
             VLLM_REF=${{ steps.ver.outputs.vllm_ref }}
           provenance: false
           sbom: false
+          # mode=max so the multi-stage builder layers (apt, torch, build deps)
+          # are cached and reused; only the vLLM clone/compile reruns per commit.
           cache-from: type=registry,ref=docker.io/${{ steps.repo.outputs.repo }}:buildcache
-          cache-to: type=registry,ref=docker.io/${{ steps.repo.outputs.repo }}:buildcache,mode=min,image-manifest=true,oci-mediatypes=true
+          cache-to: type=registry,ref=docker.io/${{ steps.repo.outputs.repo }}:buildcache,mode=max,image-manifest=true,oci-mediatypes=true
 
       - name: Push image (with retries)
         run: |

--- a/.github/workflows/build-ubuntu-nightly.yml
+++ b/.github/workflows/build-ubuntu-nightly.yml
@@ -130,15 +130,16 @@ jobs:
             org.opencontainers.image.revision=${{ github.sha }}
             org.opencontainers.image.version=${{ steps.ver.outputs.combo }}
 
-      - name: Build image (no push)
+      # Push directly from buildx (no `load`) — avoids materializing the full
+      # ~26GB image locally, which overflows the runner disk.
+      - name: Build & push image
         id: build
         uses: docker/build-push-action@v6
         with:
           context: .
           file: ./Dockerfile.ubuntu
           platforms: linux/amd64
-          push: false
-          load: true
+          push: true
           pull: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
@@ -153,26 +154,6 @@ jobs:
           # are cached and reused; only the vLLM clone/compile reruns per commit.
           cache-from: type=registry,ref=docker.io/${{ steps.repo.outputs.repo }}:buildcache
           cache-to: type=registry,ref=docker.io/${{ steps.repo.outputs.repo }}:buildcache,mode=max,image-manifest=true,oci-mediatypes=true
-
-      - name: Push image (with retries)
-        run: |
-          set -eux
-          TAGS="${{ steps.meta.outputs.tags }}"
-          for tag in $TAGS; do
-            for attempt in 1 2 3; do
-              echo "Pushing $tag (attempt $attempt/3)..."
-              if docker push "$tag"; then
-                echo "✅ Pushed $tag"
-                break
-              fi
-              if [ "$attempt" -eq 3 ]; then
-                echo "❌ Failed to push $tag after 3 attempts"
-                exit 1
-              fi
-              echo "⏳ Retrying in 30s..."
-              sleep 30
-            done
-          done
 
       - name: Prune buildx cache
         if: always()

--- a/.github/workflows/build-ubuntu-nightly.yml
+++ b/.github/workflows/build-ubuntu-nightly.yml
@@ -1,0 +1,178 @@
+name: build-ubuntu-nightly
+
+# Bleeding-edge sibling of build-ubuntu-stable. Same Ubuntu + official stable
+# ROCm base (Dockerfile.ubuntu), but builds vLLM from main HEAD instead of the
+# latest stable release tag — for trying brand-new model archs/features that
+# need vLLM main before they land in a tagged release (e.g. block-diffusion
+# DiffusionGemma).
+#
+# Differences from the stable pipeline:
+#   - MANUAL ONLY (workflow_dispatch, no cron).
+#   - Publishes to a SEPARATE repo (vllm-rocm-gfx1151-nightly) so it never
+#     clobbers the stable repo's :latest.
+#   - Tags are just :latest + a build date-time stamp (no version-stamped,
+#     skip-on-unchanged tag — every manual run is an intentional fresh build).
+# torch + ROCm still come from the stable channel/base; "nightly" here means
+# bleeding-edge vLLM, not bleeding-edge torch (we deliberately stay off the
+# torch-nightly treadmill). The built vLLM commit is recorded in the image
+# labels for traceability.
+
+on:
+  workflow_dispatch:
+    inputs:
+      vllm_ref:
+        description: "vLLM commit/tag to build (empty = current main HEAD)"
+        required: false
+        default: ""
+
+env:
+  DOCKER_BUILDKIT: "1"
+  ROCM_BASE: docker.io/rocm/dev-ubuntu-24.04:7.2.4-complete
+  TORCH_INDEX: https://download.pytorch.org/whl/rocm7.2
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Resolve image repo (from owner)
+        id: repo
+        run: |
+          set -euo pipefail
+          OWNER=$(echo "${{ github.repository_owner }}" | tr '[:upper:]' '[:lower:]')
+          REPO="${OWNER}/vllm-rocm-gfx1151-nightly"
+          echo "Image repo: docker.io/${REPO}"
+          echo "repo=${REPO}" >> "$GITHUB_OUTPUT"
+
+      - name: Resolve versions (vLLM = main HEAD)
+        id: ver
+        run: |
+          set -euo pipefail
+          ROCM_VER=$(echo "${ROCM_BASE}" | sed -E 's/.*:([0-9][0-9.]*)-complete$/\1/')
+          TORCH_FULL=$(curl -fsSL "${TORCH_INDEX}/torch/" \
+            | grep -oE 'torch-[0-9][0-9.]*\+rocm[0-9.]+-cp312' \
+            | sed -E 's/^torch-//; s/-cp312$//' \
+            | sort -V | tail -n1)
+          VLLM_REF="${{ github.event.inputs.vllm_ref }}"
+          if [ -z "$VLLM_REF" ]; then
+            # Bleeding edge: current main HEAD (short sha).
+            VLLM_REF=$(git ls-remote https://github.com/vllm-project/vllm.git HEAD \
+              | awk '{print $1}' | cut -c1-7)
+          fi
+          if [ -z "$ROCM_VER" ] || [ -z "$TORCH_FULL" ] || [ -z "$VLLM_REF" ]; then
+            echo "Failed to resolve versions: rocm='$ROCM_VER' torch='$TORCH_FULL' vllm='$VLLM_REF'" >&2
+            exit 1
+          fi
+          COMBO="rocm${ROCM_VER}-torch${TORCH_FULL%%+*}-vllm${VLLM_REF}"
+          echo "torch_full=${TORCH_FULL}" >> "$GITHUB_OUTPUT"
+          echo "vllm_ref=${VLLM_REF}"     >> "$GITHUB_OUTPUT"
+          echo "combo=${COMBO}"           >> "$GITHUB_OUTPUT"
+          echo "Building nightly: ${COMBO} (vLLM ${VLLM_REF}, torch ${TORCH_FULL})"
+
+      - name: Put Docker on /mnt
+        run: |
+          set -eux
+          echo '{ "data-root": "/mnt/docker" }' | sudo tee /etc/docker/daemon.json
+          sudo systemctl stop docker
+          sudo rm -rf /var/lib/docker || true
+          sudo mkdir -p /mnt/docker
+          sudo systemctl start docker
+          docker info | grep "Docker Root Dir"
+
+      - name: Free disk space
+        shell: bash
+        run: |
+          set -euxo pipefail
+          echo "Disk BEFORE:"; df -h
+          sudo rm -rf /usr/local/lib/android /usr/share/dotnet /opt/ghc || true
+          sudo rm -rf /opt/hostedtoolcache/CodeQL /opt/hostedtoolcache/go || true
+          docker system prune -af || true
+          docker builder prune -af || true
+          sudo apt-get clean
+          sudo rm -rf /var/lib/apt/lists/*
+          sudo rm -rf /opt/hostedtoolcache
+          echo "Disk AFTER:"; df -h
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: BuildKit GC config (8GB cap)
+        run: |
+          cat > /tmp/buildkitd.toml <<'EOF'
+          [worker.oci]
+            gc = true
+            gckeepstorage = 8000   # MB
+          EOF
+
+      - name: Set up Buildx (with GC)
+        uses: docker/setup-buildx-action@v3
+        with:
+          buildkitd-flags: --config /tmp/buildkitd.toml
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: docker.io/${{ steps.repo.outputs.repo }}
+          tags: |
+            type=raw,value=latest
+            type=raw,value={{date 'YYYYMMDD-HHmmss'}}
+          labels: |
+            org.opencontainers.image.source=https://github.com/${{ github.repository }}
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.version=${{ steps.ver.outputs.combo }}
+
+      - name: Build image (no push)
+        id: build
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile.ubuntu
+          platforms: linux/amd64
+          push: false
+          load: true
+          pull: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            ROCM_BASE=${{ env.ROCM_BASE }}
+            TORCH_INDEX=${{ env.TORCH_INDEX }}
+            TORCH_VERSION=${{ steps.ver.outputs.torch_full }}
+            VLLM_REF=${{ steps.ver.outputs.vllm_ref }}
+          provenance: false
+          sbom: false
+          cache-from: type=registry,ref=docker.io/${{ steps.repo.outputs.repo }}:buildcache
+          cache-to: type=registry,ref=docker.io/${{ steps.repo.outputs.repo }}:buildcache,mode=min,image-manifest=true,oci-mediatypes=true
+
+      - name: Push image (with retries)
+        run: |
+          set -eux
+          TAGS="${{ steps.meta.outputs.tags }}"
+          for tag in $TAGS; do
+            for attempt in 1 2 3; do
+              echo "Pushing $tag (attempt $attempt/3)..."
+              if docker push "$tag"; then
+                echo "✅ Pushed $tag"
+                break
+              fi
+              if [ "$attempt" -eq 3 ]; then
+                echo "❌ Failed to push $tag after 3 attempts"
+                exit 1
+              fi
+              echo "⏳ Retrying in 30s..."
+              sleep 30
+            done
+          done
+
+      - name: Prune buildx cache
+        if: always()
+        run: |
+          docker buildx prune -af --verbose --min-free-space 4gb || true

--- a/.github/workflows/build-ubuntu-stable.yml
+++ b/.github/workflows/build-ubuntu-stable.yml
@@ -1,0 +1,175 @@
+name: build-ubuntu-stable
+
+# Parallel, non-breaking pipeline for the greenfield Ubuntu + official-ROCm
+# image (Dockerfile.ubuntu). Publishes to a DIFFERENT repo than the TheRock
+# pipeline (build-and-publish.yml -> *vllm-therock-gfx1151*), so the two tracks
+# never collide:
+#   - vllm-therock-gfx1151  : Fedora + TheRock ROCm nightlies (existing)
+#   - vllm-rocm-gfx1151      : Ubuntu + official stable ROCm 7.2.4 (this one)
+#
+# The weekly cron refreshes ALL moving dependencies and rebuilds:
+#   - vLLM         -> latest stable release tag, resolved at build time
+#   - torch/ROCm   -> latest in the rocm7.2 stable wheel channel + --pull on the
+#                     rocm/dev-ubuntu-24.04:7.2.4-complete base and apt packages
+# A manual run can pin vllm_ref to any tag/commit (e.g. an edge commit for
+# main-only models like DiffusionGemma) without touching the cron default.
+
+on:
+  schedule:
+    # Mondays 06:00 UTC — weekly dependency refresh + rebuild
+    - cron: "0 6 * * 1"
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Base image tag to publish"
+        required: true
+        default: "stable"
+      vllm_ref:
+        description: "vLLM tag/commit to build (empty = latest stable release tag)"
+        required: false
+        default: ""
+
+env:
+  IMAGE_REPO: kyuz0/vllm-rocm-gfx1151
+  DOCKER_BUILDKIT: "1"
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Put Docker on /mnt
+        run: |
+          set -eux
+          echo '{ "data-root": "/mnt/docker" }' | sudo tee /etc/docker/daemon.json
+          sudo systemctl stop docker
+          sudo rm -rf /var/lib/docker || true
+          sudo mkdir -p /mnt/docker
+          sudo systemctl start docker
+          docker info | grep "Docker Root Dir"
+
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Free disk space
+        shell: bash
+        run: |
+          set -euxo pipefail
+          echo "Disk BEFORE:"; df -h
+          sudo rm -rf /usr/local/lib/android /usr/share/dotnet /opt/ghc || true
+          sudo rm -rf /opt/hostedtoolcache/CodeQL /opt/hostedtoolcache/go || true
+          docker system prune -af || true
+          docker builder prune -af || true
+          sudo apt-get clean
+          sudo rm -rf /var/lib/apt/lists/*
+          sudo rm -rf /opt/hostedtoolcache
+          echo "Disk AFTER:"; df -h
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: BuildKit GC config (8GB cap)
+        run: |
+          cat > /tmp/buildkitd.toml <<'EOF'
+          [worker.oci]
+            gc = true
+            gckeepstorage = 8000   # MB
+          EOF
+
+      - name: Set up Buildx (with GC)
+        uses: docker/setup-buildx-action@v3
+        with:
+          buildkitd-flags: --config /tmp/buildkitd.toml
+
+      - name: Resolve base tag
+        id: basetag
+        run: |
+          TAG="${{ github.event.inputs.tag }}"
+          [ -z "$TAG" ] && TAG="stable"
+          echo "Base tag: $TAG"
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+
+      - name: Resolve vLLM ref
+        id: vllm-ref
+        run: |
+          set -euo pipefail
+          REF="${{ github.event.inputs.vllm_ref }}"
+          if [ -z "$REF" ]; then
+            # Latest stable vLLM release tag (vMAJOR.MINOR.PATCH only — skip rc/dev/a/b).
+            REF=$(git ls-remote --tags --refs https://github.com/vllm-project/vllm.git \
+                  | awk '{print $2}' | sed 's#refs/tags/##' \
+                  | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' \
+                  | sort -V | tail -n1)
+          fi
+          if [ -z "$REF" ]; then
+            echo "Failed to resolve a vLLM ref" >&2
+            exit 1
+          fi
+          # Short, tag-safe slug for the image tag (strip refs/, keep alnum/._-).
+          SLUG=$(echo "$REF" | sed 's/[^A-Za-z0-9._-]/-/g' | cut -c1-32)
+          echo "Resolved vLLM ref: $REF (slug: $SLUG)"
+          echo "ref=$REF" >> "$GITHUB_OUTPUT"
+          echo "slug=$SLUG" >> "$GITHUB_OUTPUT"
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: docker.io/${{ env.IMAGE_REPO }}
+          tags: |
+            type=raw,value=${{ steps.basetag.outputs.tag }}
+            type=sha
+            type=raw,value={{date 'YYYYMMDD-HHmmss'}}
+            type=raw,value=${{ steps.basetag.outputs.tag }}-vllm-${{ steps.vllm-ref.outputs.slug }}
+          labels: |
+            org.opencontainers.image.source=https://github.com/${{ github.repository }}
+            org.opencontainers.image.revision=${{ github.sha }}
+
+      - name: Build image (no push)
+        id: build
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile.ubuntu
+          platforms: linux/amd64
+          push: false
+          load: true
+          pull: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            VLLM_REF=${{ steps.vllm-ref.outputs.ref }}
+          provenance: false
+          sbom: false
+          cache-from: type=registry,ref=docker.io/${{ env.IMAGE_REPO }}:buildcache
+          cache-to: type=registry,ref=docker.io/${{ env.IMAGE_REPO }}:buildcache,mode=min,image-manifest=true,oci-mediatypes=true
+
+      - name: Push image (with retries)
+        run: |
+          set -eux
+          TAGS="${{ steps.meta.outputs.tags }}"
+          for tag in $TAGS; do
+            for attempt in 1 2 3; do
+              echo "Pushing $tag (attempt $attempt/3)..."
+              if docker push "$tag"; then
+                echo "✅ Pushed $tag"
+                break
+              fi
+              if [ "$attempt" -eq 3 ]; then
+                echo "❌ Failed to push $tag after 3 attempts"
+                exit 1
+              fi
+              echo "⏳ Retrying in 30s..."
+              sleep 30
+            done
+          done
+
+      - name: Prune buildx cache
+        if: always()
+        run: |
+          docker buildx prune -af --verbose --min-free-space 4gb || true

--- a/.github/workflows/build-ubuntu-stable.yml
+++ b/.github/workflows/build-ubuntu-stable.yml
@@ -198,8 +198,12 @@ jobs:
             VLLM_REF=${{ steps.ver.outputs.vllm_ref }}
           provenance: false
           sbom: false
+          # mode=max exports cache for ALL stages incl. the multi-stage builder
+          # (apt, torch download, build deps, vLLM compile). With mode=min only
+          # the final runtime stage is cached, so the builder rebuilds from
+          # scratch every run — defeating reuse when only vLLM changed.
           cache-from: type=registry,ref=docker.io/${{ steps.repo.outputs.repo }}:buildcache
-          cache-to: type=registry,ref=docker.io/${{ steps.repo.outputs.repo }}:buildcache,mode=min,image-manifest=true,oci-mediatypes=true
+          cache-to: type=registry,ref=docker.io/${{ steps.repo.outputs.repo }}:buildcache,mode=max,image-manifest=true,oci-mediatypes=true
 
       - name: Push image (with retries)
         if: steps.check.outputs.skip != 'true'

--- a/.github/workflows/build-ubuntu-stable.yml
+++ b/.github/workflows/build-ubuntu-stable.yml
@@ -178,7 +178,11 @@ jobs:
             org.opencontainers.image.revision=${{ github.sha }}
             org.opencontainers.image.version=${{ steps.ver.outputs.version_tag }}
 
-      - name: Build image (no push)
+      # Push directly from buildx (no `load`): streams compressed layers to the
+      # registry without ever materializing the full ~26GB image as a local
+      # tarball + extracted daemon copy. `load: true` did exactly that and blew
+      # the runner's disk ("no space left" while importing to docker).
+      - name: Build & push image
         if: steps.check.outputs.skip != 'true'
         id: build
         uses: docker/build-push-action@v6
@@ -186,8 +190,7 @@ jobs:
           context: .
           file: ./Dockerfile.ubuntu
           platforms: linux/amd64
-          push: false
-          load: true
+          push: true
           pull: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
@@ -204,27 +207,6 @@ jobs:
           # scratch every run — defeating reuse when only vLLM changed.
           cache-from: type=registry,ref=docker.io/${{ steps.repo.outputs.repo }}:buildcache
           cache-to: type=registry,ref=docker.io/${{ steps.repo.outputs.repo }}:buildcache,mode=max,image-manifest=true,oci-mediatypes=true
-
-      - name: Push image (with retries)
-        if: steps.check.outputs.skip != 'true'
-        run: |
-          set -eux
-          TAGS="${{ steps.meta.outputs.tags }}"
-          for tag in $TAGS; do
-            for attempt in 1 2 3; do
-              echo "Pushing $tag (attempt $attempt/3)..."
-              if docker push "$tag"; then
-                echo "✅ Pushed $tag"
-                break
-              fi
-              if [ "$attempt" -eq 3 ]; then
-                echo "❌ Failed to push $tag after 3 attempts"
-                exit 1
-              fi
-              echo "⏳ Retrying in 30s..."
-              sleep 30
-            done
-          done
 
       - name: Prune buildx cache
         if: always()

--- a/.github/workflows/build-ubuntu-stable.yml
+++ b/.github/workflows/build-ubuntu-stable.yml
@@ -5,39 +5,119 @@ name: build-ubuntu-stable
 # pipeline (build-and-publish.yml -> *vllm-therock-gfx1151*), so the two tracks
 # never collide:
 #   - vllm-therock-gfx1151  : Fedora + TheRock ROCm nightlies (existing)
-#   - vllm-rocm-gfx1151      : Ubuntu + official stable ROCm 7.2.4 (this one)
+#   - vllm-rocm-gfx1151      : Ubuntu + official stable ROCm (this one)
 #
-# The weekly cron refreshes ALL moving dependencies and rebuilds:
-#   - vLLM         -> latest stable release tag, resolved at build time
-#   - torch/ROCm   -> latest in the rocm7.2 stable wheel channel + --pull on the
-#                     rocm/dev-ubuntu-24.04:7.2.4-complete base and apt packages
-# A manual run can pin vllm_ref to any tag/commit (e.g. an edge commit for
-# main-only models like DiffusionGemma) without touching the cron default.
+# The image repo is derived from the repo OWNER, so this same file publishes to
+# the fork's Docker Hub when it runs on the fork (lafunamor/...) and to kyuz0's
+# if it ever lands upstream (kyuz0/...). No hard-coded namespace.
+#
+# DAILY cron chases all-latest and rebuilds ONLY when the resolved combination
+# changed:
+#   - vLLM  -> latest stable release tag (resolved at build time)
+#   - torch -> latest wheel in the rocm7.2 stable channel
+#   - ROCm  -> the pinned base image (rocm/dev-ubuntu-24.04:<ver>-complete);
+#              this is the one deliberate anchor, because the torch wheel
+#              channel (TORCH_INDEX) must match the ROCm minor. Bump both
+#              together when moving ROCm.
+# The three resolved versions are baked into an immutable tag
+# (rocm<X>-torch<Y>-vllm<Z>); if that tag already exists in the registry the
+# build is skipped, so an unchanged day is a cheap no-op.
 
 on:
   schedule:
-    # Mondays 06:00 UTC — weekly dependency refresh + rebuild
-    - cron: "0 6 * * 1"
+    # Daily 06:00 UTC — chase latest, build only if the combo changed
+    - cron: "0 6 * * *"
   workflow_dispatch:
     inputs:
-      tag:
-        description: "Base image tag to publish"
-        required: true
-        default: "stable"
       vllm_ref:
         description: "vLLM tag/commit to build (empty = latest stable release tag)"
         required: false
         default: ""
+      force:
+        description: "Rebuild even if the version tag already exists"
+        type: boolean
+        required: false
+        default: false
 
 env:
-  IMAGE_REPO: kyuz0/vllm-rocm-gfx1151
   DOCKER_BUILDKIT: "1"
+  # ROCm anchor + matching torch wheel channel (bump these two together).
+  ROCM_BASE: docker.io/rocm/dev-ubuntu-24.04:7.2.4-complete
+  TORCH_INDEX: https://download.pytorch.org/whl/rocm7.2
 
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Resolve image repo (from owner)
+        id: repo
+        run: |
+          set -euo pipefail
+          OWNER=$(echo "${{ github.repository_owner }}" | tr '[:upper:]' '[:lower:]')
+          REPO="${OWNER}/vllm-rocm-gfx1151"
+          echo "Image repo: docker.io/${REPO}"
+          echo "repo=${REPO}" >> "$GITHUB_OUTPUT"
+
+      - name: Resolve latest versions
+        id: ver
+        run: |
+          set -euo pipefail
+          # ROCm version from the pinned base image tag (e.g. 7.2.4).
+          ROCM_VER=$(echo "${ROCM_BASE}" | sed -E 's/.*:([0-9][0-9.]*)-complete$/\1/')
+          # torch: latest cp312 wheel in the rocm channel (e.g. 2.12.0+rocm7.2).
+          TORCH_FULL=$(curl -fsSL "${TORCH_INDEX}/torch/" \
+            | grep -oE 'torch-[0-9][0-9.]*\+rocm[0-9.]+-cp312' \
+            | sed -E 's/^torch-//; s/-cp312$//' \
+            | sort -V | tail -n1)
+          TORCH_VER="${TORCH_FULL%%+*}"
+          # vLLM: manual override, else latest stable release tag (skip rc/dev/a/b).
+          VLLM_REF="${{ github.event.inputs.vllm_ref }}"
+          if [ -z "$VLLM_REF" ]; then
+            VLLM_REF=$(git ls-remote --tags --refs https://github.com/vllm-project/vllm.git \
+              | awk '{print $2}' | sed 's#refs/tags/##' \
+              | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' \
+              | sort -V | tail -n1)
+          fi
+          if [ -z "$ROCM_VER" ] || [ -z "$TORCH_FULL" ] || [ -z "$VLLM_REF" ]; then
+            echo "Failed to resolve versions: rocm='$ROCM_VER' torch='$TORCH_FULL' vllm='$VLLM_REF'" >&2
+            exit 1
+          fi
+          # vLLM slug for the tag: strip leading v, keep alnum/._-.
+          VLLM_SLUG=$(echo "${VLLM_REF#v}" | sed 's/[^A-Za-z0-9._-]/-/g' | cut -c1-24)
+          VERSION_TAG="rocm${ROCM_VER}-torch${TORCH_VER}-vllm${VLLM_SLUG}"
+          echo "rocm=${ROCM_VER}"            >> "$GITHUB_OUTPUT"
+          echo "torch_full=${TORCH_FULL}"    >> "$GITHUB_OUTPUT"
+          echo "vllm_ref=${VLLM_REF}"        >> "$GITHUB_OUTPUT"
+          echo "version_tag=${VERSION_TAG}"  >> "$GITHUB_OUTPUT"
+          echo "Resolved: ${VERSION_TAG} (vLLM ref ${VLLM_REF}, torch ${TORCH_FULL})"
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Check if combo already built
+        id: check
+        run: |
+          set -uo pipefail
+          REF="docker.io/${{ steps.repo.outputs.repo }}:${{ steps.ver.outputs.version_tag }}"
+          if [ "${{ github.event.inputs.force }}" = "true" ]; then
+            echo "force=true -> rebuilding regardless"
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          elif docker buildx imagetools inspect "$REF" >/dev/null 2>&1; then
+            echo "✅ $REF already exists — nothing changed, skipping build"
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "🆕 $REF not found — building"
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Put Docker on /mnt
+        if: steps.check.outputs.skip != 'true'
         run: |
           set -eux
           echo '{ "data-root": "/mnt/docker" }' | sudo tee /etc/docker/daemon.json
@@ -46,11 +126,11 @@ jobs:
           sudo mkdir -p /mnt/docker
           sudo systemctl start docker
           docker info | grep "Docker Root Dir"
-
-      - name: Checkout
-        uses: actions/checkout@v4
+          # docker daemon was restarted onto /mnt — re-auth for the push.
+          echo "${{ secrets.DOCKERHUB_TOKEN }}" | docker login -u "${{ secrets.DOCKERHUB_USERNAME }}" --password-stdin
 
       - name: Free disk space
+        if: steps.check.outputs.skip != 'true'
         shell: bash
         run: |
           set -euxo pipefail
@@ -65,9 +145,11 @@ jobs:
           echo "Disk AFTER:"; df -h
 
       - name: Set up QEMU
+        if: steps.check.outputs.skip != 'true'
         uses: docker/setup-qemu-action@v3
 
       - name: BuildKit GC config (8GB cap)
+        if: steps.check.outputs.skip != 'true'
         run: |
           cat > /tmp/buildkitd.toml <<'EOF'
           [worker.oci]
@@ -76,61 +158,28 @@ jobs:
           EOF
 
       - name: Set up Buildx (with GC)
+        if: steps.check.outputs.skip != 'true'
         uses: docker/setup-buildx-action@v3
         with:
           buildkitd-flags: --config /tmp/buildkitd.toml
 
-      - name: Resolve base tag
-        id: basetag
-        run: |
-          TAG="${{ github.event.inputs.tag }}"
-          [ -z "$TAG" ] && TAG="stable"
-          echo "Base tag: $TAG"
-          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
-
-      - name: Resolve vLLM ref
-        id: vllm-ref
-        run: |
-          set -euo pipefail
-          REF="${{ github.event.inputs.vllm_ref }}"
-          if [ -z "$REF" ]; then
-            # Latest stable vLLM release tag (vMAJOR.MINOR.PATCH only — skip rc/dev/a/b).
-            REF=$(git ls-remote --tags --refs https://github.com/vllm-project/vllm.git \
-                  | awk '{print $2}' | sed 's#refs/tags/##' \
-                  | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' \
-                  | sort -V | tail -n1)
-          fi
-          if [ -z "$REF" ]; then
-            echo "Failed to resolve a vLLM ref" >&2
-            exit 1
-          fi
-          # Short, tag-safe slug for the image tag (strip refs/, keep alnum/._-).
-          SLUG=$(echo "$REF" | sed 's/[^A-Za-z0-9._-]/-/g' | cut -c1-32)
-          echo "Resolved vLLM ref: $REF (slug: $SLUG)"
-          echo "ref=$REF" >> "$GITHUB_OUTPUT"
-          echo "slug=$SLUG" >> "$GITHUB_OUTPUT"
-
-      - name: Log in to Docker Hub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-
       - name: Docker meta
+        if: steps.check.outputs.skip != 'true'
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: docker.io/${{ env.IMAGE_REPO }}
+          images: docker.io/${{ steps.repo.outputs.repo }}
           tags: |
-            type=raw,value=${{ steps.basetag.outputs.tag }}
-            type=sha
+            type=raw,value=${{ steps.ver.outputs.version_tag }}
+            type=raw,value=latest
             type=raw,value={{date 'YYYYMMDD-HHmmss'}}
-            type=raw,value=${{ steps.basetag.outputs.tag }}-vllm-${{ steps.vllm-ref.outputs.slug }}
           labels: |
             org.opencontainers.image.source=https://github.com/${{ github.repository }}
             org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.version=${{ steps.ver.outputs.version_tag }}
 
       - name: Build image (no push)
+        if: steps.check.outputs.skip != 'true'
         id: build
         uses: docker/build-push-action@v6
         with:
@@ -143,13 +192,17 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
-            VLLM_REF=${{ steps.vllm-ref.outputs.ref }}
+            ROCM_BASE=${{ env.ROCM_BASE }}
+            TORCH_INDEX=${{ env.TORCH_INDEX }}
+            TORCH_VERSION=${{ steps.ver.outputs.torch_full }}
+            VLLM_REF=${{ steps.ver.outputs.vllm_ref }}
           provenance: false
           sbom: false
-          cache-from: type=registry,ref=docker.io/${{ env.IMAGE_REPO }}:buildcache
-          cache-to: type=registry,ref=docker.io/${{ env.IMAGE_REPO }}:buildcache,mode=min,image-manifest=true,oci-mediatypes=true
+          cache-from: type=registry,ref=docker.io/${{ steps.repo.outputs.repo }}:buildcache
+          cache-to: type=registry,ref=docker.io/${{ steps.repo.outputs.repo }}:buildcache,mode=min,image-manifest=true,oci-mediatypes=true
 
       - name: Push image (with retries)
+        if: steps.check.outputs.skip != 'true'
         run: |
           set -eux
           TAGS="${{ steps.meta.outputs.tags }}"

--- a/Dockerfile.ubuntu
+++ b/Dockerfile.ubuntu
@@ -55,9 +55,15 @@ ENV ROCM_PATH=/opt/rocm HIP_PATH=/opt/rocm VLLM_TARGET_DEVICE=rocm \
 ARG VLLM_REF=eb28452b1
 ARG MAX_JOBS=4
 ENV MAX_JOBS=${MAX_JOBS}
-RUN git clone https://github.com/vllm-project/vllm.git /opt/vllm
+# Clone + checkout in ONE RUN keyed on VLLM_REF: it's a cache hit while the ref
+# is unchanged (so the expensive torch/apt/build-dep layers above stay cached),
+# and re-clones fresh whenever VLLM_REF changes — which also avoids a stale
+# cached clone failing `git checkout` on a newly-released tag/commit.
+WORKDIR /opt
+RUN git clone https://github.com/vllm-project/vllm.git /opt/vllm && \
+    cd /opt/vllm && \
+    if [ -n "$VLLM_REF" ]; then echo "Checking out vLLM $VLLM_REF" && git checkout "$VLLM_REF"; fi
 WORKDIR /opt/vllm
-RUN if [ -n "$VLLM_REF" ]; then echo "Checking out vLLM $VLLM_REF" && git checkout "$VLLM_REF"; fi
 COPY scripts/patch_strix.py /opt/vllm/patch_strix.py
 RUN python /opt/vllm/patch_strix.py
 RUN export HIP_DEVICE_LIB_PATH=$(find /opt/rocm -type d -name bitcode -print -quit) && \

--- a/Dockerfile.ubuntu
+++ b/Dockerfile.ubuntu
@@ -104,9 +104,13 @@ RUN rm -f /opt/rocm/lib/*.a && \
 FROM docker.io/ubuntu:24.04 AS runtime
 ENV DEBIAN_FRONTEND=noninteractive
 
-# Runtime system deps for the ROCm libs + torch (no build tools, no -dev).
+# Runtime system deps for the ROCm libs + torch.
+# gcc + python3.12-dev are required at RUNTIME: Triton JIT-compiles a host-side
+# driver module on first kernel use (sampler, attention, fp8_triton, ...), which
+# needs a C compiler + Python.h. Without them the slim image can't run any Triton
+# kernel ("Failed to find C compiler"). Kept minimal otherwise.
 RUN apt-get update && apt-get install -y --no-install-recommends \
-      python3.12 ca-certificates curl \
+      python3.12 python3.12-dev gcc ca-certificates curl \
       libatomic1 libnuma1 libgomp1 libelf1 libdrm2 libdrm-amdgpu1 libtinfo6 zlib1g libssl3 \
       libgoogle-perftools4 libibverbs1 librdmacm1 \
     && apt-get clean && rm -rf /var/lib/apt/lists/*

--- a/Dockerfile.ubuntu
+++ b/Dockerfile.ubuntu
@@ -2,18 +2,21 @@
 # Greenfield Ubuntu + official ROCm build for gfx1151 (Strix Halo).
 #
 # STABLE track (default): official ROCm 7.2.4 dev SDK base + stable PyTorch ROCm
-# wheel (gfx1151 is native in the rocm7.2 wheel). No TheRock nightly, no tarball.
-# Dual-track ready: a nightly track overrides ROCM_BASE -> ubuntu:24.04 + the
-# TheRock nightly SDK, and TORCH_INDEX/TORCH_VERSION -> the nightly pip index.
+# wheel (gfx1151 native). No TheRock nightly, no tarball.
 #
-# First pass intentionally OMITS the custom flash-attention/AITER build to test
-# whether it's needed on gfx1151 (we serve with TRITON_ATTN; patch_strix gates
-# AITER off on gfx1x). Add it back if vLLM needs aiter present at runtime.
+# Multi-stage: build in the full "-complete" SDK, then ship a slim runtime stage
+# that carries only the venv + a gfx1151-pruned /opt/rocm (drops all-arch math
+# kernels, static build libs, and components vLLM doesn't link). This is what
+# brings the image down from ~49 GB (single-stage) toward TheRock parity.
+#
+# First pass omits the custom flash-attention/AITER build (validated unnecessary
+# on gfx1151 — Triton path; see the AITER issue).
 ARG ROCM_BASE=docker.io/rocm/dev-ubuntu-24.04:7.2.4-complete
-FROM ${ROCM_BASE}
+
+# ============================ Stage 1: builder ============================
+FROM ${ROCM_BASE} AS builder
 ENV DEBIAN_FRONTEND=noninteractive
 
-# 1. Minimal extra deps (base already ships ROCm SDK, gcc, cmake, git, python3.12)
 RUN apt-get update && apt-get install -y --no-install-recommends \
       python3.12-venv python3.12-dev python3-pip \
       git aria2 ffmpeg vim nano dialog rsync curl ca-certificates xz-utils patch \
@@ -22,22 +25,18 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
       rustc cargo \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 
-# 2. Python venv
 RUN python3.12 -m venv /opt/venv
 ENV VIRTUAL_ENV=/opt/venv PATH=/opt/venv/bin:$PATH PIP_NO_CACHE_DIR=1 PYTHONNOUSERSITE=1
 RUN python -m pip install --upgrade pip wheel packaging "setuptools<80.0.0" "setuptools-rust>=1.9.0"
 
-# 3. PyTorch — STABLE wheel, gfx1151 native
 ARG TORCH_INDEX=https://download.pytorch.org/whl/rocm7.2
 ARG TORCH_VERSION=2.12.0+rocm7.2
 RUN python -m pip install --index-url ${TORCH_INDEX} \
       "torch==${TORCH_VERSION}" torchaudio torchvision
 
-# 4. Build deps
 RUN python -m pip install --upgrade cmake ninja numpy "setuptools-scm>=8" \
       "setuptools<80.0.0" scikit-build-core pybind11 numba scipy
 
-# 5. ROCm / build env (the SDK base sets ROCm paths; we add our knobs)
 ENV ROCM_PATH=/opt/rocm HIP_PATH=/opt/rocm VLLM_TARGET_DEVICE=rocm \
     PYTORCH_ROCM_ARCH=gfx1151 HIP_ARCHITECTURES=gfx1151 AMDGPU_TARGETS=gfx1151 \
     ROCBLAS_USE_HIPBLASLT=1 TORCH_ROCM_AOTRITON_ENABLE_EXPERIMENTAL=1 \
@@ -45,23 +44,64 @@ ENV ROCM_PATH=/opt/rocm HIP_PATH=/opt/rocm VLLM_TARGET_DEVICE=rocm \
     CC=/opt/rocm/llvm/bin/clang CXX=/opt/rocm/llvm/bin/clang++ \
     LD_LIBRARY_PATH=/opt/rocm/lib:/opt/rocm/lib64
 
-# 6. vLLM — build from source against official ROCm 7.2.4
-ARG VLLM_COMMIT=eb28452b1
+# vLLM ref: a STABLE RELEASE TAG (preferred) or a main commit. git checkout
+# accepts either. Two tracks:
+#   stable track -> a release tag, e.g. VLLM_REF=v0.23.0 (reproducible; per the
+#                   "stable tags only" policy). Note: v0.23.0 does NOT yet carry
+#                   DiffusionGemma (landed on main after the v0.23.0 cut).
+#   edge track   -> a main commit, e.g. VLLM_REF=eb28452b1, for models not yet
+#                   in a release (DiffusionGemma until ~v0.24.0).
+# Default is the validated edge commit; set --build-arg VLLM_REF=v0.23.0 for stable.
+ARG VLLM_REF=eb28452b1
 ARG MAX_JOBS=4
 ENV MAX_JOBS=${MAX_JOBS}
 RUN git clone https://github.com/vllm-project/vllm.git /opt/vllm
 WORKDIR /opt/vllm
-RUN if [ -n "$VLLM_COMMIT" ]; then echo "Pinning vLLM to $VLLM_COMMIT" && git checkout "$VLLM_COMMIT"; fi
+RUN if [ -n "$VLLM_REF" ]; then echo "Checking out vLLM $VLLM_REF" && git checkout "$VLLM_REF"; fi
 COPY scripts/patch_strix.py /opt/vllm/patch_strix.py
 RUN python /opt/vllm/patch_strix.py
 RUN export HIP_DEVICE_LIB_PATH=$(find /opt/rocm -type d -name bitcode -print -quit) && \
-    echo "Bitcode: $HIP_DEVICE_LIB_PATH" && \
     export CMAKE_ARGS="-DROCM_PATH=/opt/rocm -DHIP_PATH=/opt/rocm -DAMDGPU_TARGETS=gfx1151 -DHIP_ARCHITECTURES=gfx1151" && \
     python -m pip wheel --no-build-isolation --no-deps -w /tmp/dist -v . && \
-    python -m pip install /tmp/dist/*.whl && rm -rf /tmp/dist && \
-    (find /opt/venv -type f -name "*.so" -exec strip -s {} + 2>/dev/null || true)
-
+    python -m pip install /tmp/dist/*.whl && rm -rf /tmp/dist
 RUN python -m pip install ray
+
+# Prune /opt/rocm to a gfx1151 runtime set (this state is what the runtime stage copies):
+#  - static build-only archives (*.a)
+#  - all-architecture Tensile kernels except gfx1151 (hipBLASLt gfx942 alone is ~3 GB)
+#  - components vLLM/torch do not link (rocfft, rocalution)
+#  - the clang compiler binaries (build-only; keep llvm runtime libs)
+#  - docs/man
+# Then strip remaining shared objects.
+RUN rm -f /opt/rocm/lib/*.a && \
+    find /opt/rocm/lib/hipblaslt/library -name '*gfx*' ! -name '*gfx1151*' -delete 2>/dev/null || true && \
+    find /opt/rocm/lib/rocblas/library -name '*gfx*' ! -name '*gfx1151*' -delete 2>/dev/null || true && \
+    rm -f /opt/rocm/lib/librocfft* /opt/rocm/lib/librocalution* && \
+    rm -rf /opt/rocm/lib/llvm/bin /opt/rocm/share/doc /opt/rocm/share/man && \
+    (find /opt/rocm/lib /opt/venv -name '*.so*' -type f -exec strip -s {} + 2>/dev/null || true)
+
+# ============================ Stage 2: runtime (slim) ============================
+FROM docker.io/ubuntu:24.04 AS runtime
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Runtime system deps for the ROCm libs + torch (no build tools, no -dev).
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      python3.12 ca-certificates curl \
+      libatomic1 libnuma1 libgomp1 libelf1 libdrm2 libdrm-amdgpu1 libtinfo6 zlib1g libssl3 \
+      libgoogle-perftools4 libibverbs1 librdmacm1 \
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
+
+COPY --from=builder /opt/rocm /opt/rocm
+COPY --from=builder /opt/venv /opt/venv
+
+ENV VIRTUAL_ENV=/opt/venv \
+    PATH=/opt/venv/bin:/opt/rocm/bin:$PATH \
+    ROCM_PATH=/opt/rocm HIP_PATH=/opt/rocm \
+    LD_LIBRARY_PATH=/opt/rocm/lib:/opt/rocm/lib64 \
+    PYTORCH_ROCM_ARCH=gfx1151 \
+    ROCBLAS_USE_HIPBLASLT=1 TORCH_ROCM_AOTRITON_ENABLE_EXPERIMENTAL=1 \
+    HIP_FORCE_DEV_KERNARG=1 VLLM_USE_TRITON_AWQ=1 MIOPEN_FIND_MODE=FAST \
+    PYTHONNOUSERSITE=1
 
 WORKDIR /opt
 CMD ["/bin/bash"]

--- a/Dockerfile.ubuntu
+++ b/Dockerfile.ubuntu
@@ -66,6 +66,20 @@ RUN git clone https://github.com/vllm-project/vllm.git /opt/vllm && \
 WORKDIR /opt/vllm
 COPY scripts/patch_strix.py /opt/vllm/patch_strix.py
 RUN python /opt/vllm/patch_strix.py
+
+# --- FP8 (W8A8) Strix Halo Triton kernels (EXPERIMENTAL / RFC — see kyuz0 #67) ---
+# @leonyurko's FP8 kernels for gfx1151 (no native FP8). patch_fp8_kernels.py routes
+# vLLM's compressed-tensors W8A8-FP8 scaled-mm path to the fused Triton dequant-GEMM;
+# the kernel modules live on PYTHONPATH (/opt/fp8, copied into the runtime stage).
+# Separate from patch_strix.py so it's independent of the is_integrated memory work.
+# Serve FP8 models with VLLM_ROCM_USE_AITER=0 + --enforce-eager.
+# https://github.com/leonyurko/vllm-fp8-strix-halo-kernel-support
+ARG FP8_KERNELS_REF=50424f5525b8382353551e3301d0da56eca0be2b
+RUN git clone https://github.com/leonyurko/vllm-fp8-strix-halo-kernel-support.git /opt/fp8 && \
+    cd /opt/fp8 && git checkout "$FP8_KERNELS_REF"
+COPY scripts/patch_fp8_kernels.py /opt/vllm/patch_fp8_kernels.py
+RUN python /opt/vllm/patch_fp8_kernels.py
+
 RUN export HIP_DEVICE_LIB_PATH=$(find /opt/rocm -type d -name bitcode -print -quit) && \
     export CMAKE_ARGS="-DROCM_PATH=/opt/rocm -DHIP_PATH=/opt/rocm -DAMDGPU_TARGETS=gfx1151 -DHIP_ARCHITECTURES=gfx1151" && \
     python -m pip wheel --no-build-isolation --no-deps -w /tmp/dist -v . && \
@@ -99,6 +113,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 COPY --from=builder /opt/rocm /opt/rocm
 COPY --from=builder /opt/venv /opt/venv
+# FP8 Triton kernels (gfx1151) — see builder stage / kyuz0 #67
+COPY --from=builder /opt/fp8 /opt/fp8
 
 ENV VIRTUAL_ENV=/opt/venv \
     PATH=/opt/venv/bin:/opt/rocm/bin:$PATH \
@@ -107,6 +123,7 @@ ENV VIRTUAL_ENV=/opt/venv \
     PYTORCH_ROCM_ARCH=gfx1151 \
     ROCBLAS_USE_HIPBLASLT=1 TORCH_ROCM_AOTRITON_ENABLE_EXPERIMENTAL=1 \
     HIP_FORCE_DEV_KERNARG=1 VLLM_USE_TRITON_AWQ=1 MIOPEN_FIND_MODE=FAST \
+    PYTHONPATH=/opt/fp8 \
     PYTHONNOUSERSITE=1
 
 WORKDIR /opt

--- a/Dockerfile.ubuntu
+++ b/Dockerfile.ubuntu
@@ -1,0 +1,67 @@
+# syntax=docker/dockerfile:1
+# Greenfield Ubuntu + official ROCm build for gfx1151 (Strix Halo).
+#
+# STABLE track (default): official ROCm 7.2.4 dev SDK base + stable PyTorch ROCm
+# wheel (gfx1151 is native in the rocm7.2 wheel). No TheRock nightly, no tarball.
+# Dual-track ready: a nightly track overrides ROCM_BASE -> ubuntu:24.04 + the
+# TheRock nightly SDK, and TORCH_INDEX/TORCH_VERSION -> the nightly pip index.
+#
+# First pass intentionally OMITS the custom flash-attention/AITER build to test
+# whether it's needed on gfx1151 (we serve with TRITON_ATTN; patch_strix gates
+# AITER off on gfx1x). Add it back if vLLM needs aiter present at runtime.
+ARG ROCM_BASE=docker.io/rocm/dev-ubuntu-24.04:7.2.4-complete
+FROM ${ROCM_BASE}
+ENV DEBIAN_FRONTEND=noninteractive
+
+# 1. Minimal extra deps (base already ships ROCm SDK, gcc, cmake, git, python3.12)
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      python3.12-venv python3.12-dev python3-pip \
+      git aria2 ffmpeg vim nano dialog rsync curl ca-certificates xz-utils patch \
+      libgoogle-perftools-dev libnuma-dev numactl \
+      libibverbs-dev ibverbs-utils rdma-core \
+      rustc cargo \
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
+
+# 2. Python venv
+RUN python3.12 -m venv /opt/venv
+ENV VIRTUAL_ENV=/opt/venv PATH=/opt/venv/bin:$PATH PIP_NO_CACHE_DIR=1 PYTHONNOUSERSITE=1
+RUN python -m pip install --upgrade pip wheel packaging "setuptools<80.0.0" "setuptools-rust>=1.9.0"
+
+# 3. PyTorch — STABLE wheel, gfx1151 native
+ARG TORCH_INDEX=https://download.pytorch.org/whl/rocm7.2
+ARG TORCH_VERSION=2.12.0+rocm7.2
+RUN python -m pip install --index-url ${TORCH_INDEX} \
+      "torch==${TORCH_VERSION}" torchaudio torchvision
+
+# 4. Build deps
+RUN python -m pip install --upgrade cmake ninja numpy "setuptools-scm>=8" \
+      "setuptools<80.0.0" scikit-build-core pybind11 numba scipy
+
+# 5. ROCm / build env (the SDK base sets ROCm paths; we add our knobs)
+ENV ROCM_PATH=/opt/rocm HIP_PATH=/opt/rocm VLLM_TARGET_DEVICE=rocm \
+    PYTORCH_ROCM_ARCH=gfx1151 HIP_ARCHITECTURES=gfx1151 AMDGPU_TARGETS=gfx1151 \
+    ROCBLAS_USE_HIPBLASLT=1 TORCH_ROCM_AOTRITON_ENABLE_EXPERIMENTAL=1 \
+    HIP_FORCE_DEV_KERNARG=1 VLLM_USE_TRITON_AWQ=1 MIOPEN_FIND_MODE=FAST \
+    CC=/opt/rocm/llvm/bin/clang CXX=/opt/rocm/llvm/bin/clang++ \
+    LD_LIBRARY_PATH=/opt/rocm/lib:/opt/rocm/lib64
+
+# 6. vLLM — build from source against official ROCm 7.2.4
+ARG VLLM_COMMIT=eb28452b1
+ARG MAX_JOBS=4
+ENV MAX_JOBS=${MAX_JOBS}
+RUN git clone https://github.com/vllm-project/vllm.git /opt/vllm
+WORKDIR /opt/vllm
+RUN if [ -n "$VLLM_COMMIT" ]; then echo "Pinning vLLM to $VLLM_COMMIT" && git checkout "$VLLM_COMMIT"; fi
+COPY scripts/patch_strix.py /opt/vllm/patch_strix.py
+RUN python /opt/vllm/patch_strix.py
+RUN export HIP_DEVICE_LIB_PATH=$(find /opt/rocm -type d -name bitcode -print -quit) && \
+    echo "Bitcode: $HIP_DEVICE_LIB_PATH" && \
+    export CMAKE_ARGS="-DROCM_PATH=/opt/rocm -DHIP_PATH=/opt/rocm -DAMDGPU_TARGETS=gfx1151 -DHIP_ARCHITECTURES=gfx1151" && \
+    python -m pip wheel --no-build-isolation --no-deps -w /tmp/dist -v . && \
+    python -m pip install /tmp/dist/*.whl && rm -rf /tmp/dist && \
+    (find /opt/venv -type f -name "*.so" -exec strip -s {} + 2>/dev/null || true)
+
+RUN python -m pip install ray
+
+WORKDIR /opt
+CMD ["/bin/bash"]

--- a/Dockerfile.ubuntu
+++ b/Dockerfile.ubuntu
@@ -86,6 +86,22 @@ RUN export HIP_DEVICE_LIB_PATH=$(find /opt/rocm -type d -name bitcode -print -qu
     python -m pip install /tmp/dist/*.whl && rm -rf /tmp/dist
 RUN python -m pip install ray
 
+# The amdsmi python bindings ship with ROCm but are not installed by default.
+# vLLM's ROCm platform imports them for device name, GCN arch and VRAM total
+# (deliberately, so those queries don't create a HIP context). Without them the
+# import fails and the platform has to be stubbed out with a MagicMock -- which
+# silently leaks mock objects into real use and crashed vLLM >= 0.25.1 at startup.
+# They work fine on gfx1151 (verified: gfx1151 / Radeon 8060S / 40 CUs), so install
+# them for real and drop the stubbing (see scripts/patch_strix.py).
+#
+# patch_amdsmi.py then works around an amdsmi bug: on APUs it reports the small BIOS
+# VRAM carveout (512 MiB) as the VRAM total instead of the unified pool the GPU
+# actually addresses (110 GiB). Fixing it here, at the layer where the bug is, means
+# vLLM needs no memory patch. Drop once it lands upstream (ROCm/rocm-systems#8419).
+RUN python -m pip install /opt/rocm/share/amd_smi
+COPY scripts/patch_amdsmi.py /opt/vllm/patch_amdsmi.py
+RUN python /opt/vllm/patch_amdsmi.py
+
 # Prune /opt/rocm to a gfx1151 runtime set (this state is what the runtime stage copies):
 #  - static build-only archives (*.a)
 #  - all-architecture Tensile kernels except gfx1151 (hipBLASLt gfx942 alone is ~3 GB)

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 An **Fedora 43** Docker/Podman container that is **Toolbx-compatible** (usable as a Fedora toolbox) for serving LLMs with **vLLM** on **AMD Ryzen AI Max “Strix Halo” (gfx1151)**. Built on the **TheRock nightly builds** for ROCm.
 
+> Also available: **Ubuntu + official stable-ROCm** image variants (daily-rebuilt and bleeding-edge) — see [Image Variants](#image-variants).
+
 ---
 
 ## 🚀 High-Performance Clustering Support (New!)
@@ -29,6 +31,7 @@ This is a hobby project maintained in my spare time. If you find these toolboxes
 
 ## Table of Contents
 
+* [Image Variants](#image-variants)
 * [Tested Models (Benchmarks)](#tested-models-benchmarks)
 * [1) Toolbx vs Docker/Podman](#1-toolbx-vs-dockerpodman)
 * [2) Quickstart — Fedora Toolbx](#2-quickstart--fedora-toolbx)
@@ -38,6 +41,28 @@ This is a hobby project maintained in my spare time. If you find these toolboxes
 * [6) Host Configuration](#6-host-configuration)
 * [7) Distributed Clustering (RDMA/RoCE)](#7-distributed-clustering-rdmaroce)
 
+
+## Image Variants
+
+Three image families are published for gfx1151, each aimed at a different need:
+
+| Image | Base / ROCm | vLLM | Cadence | Tags | Use it for |
+| :--- | :--- | :--- | :--- | :--- | :--- |
+| `kyuz0/vllm-therock-gfx1151` | Fedora 43 + **TheRock** ROCm nightlies | upstream `main` | manual | `:stable`, `:latest` | The original toolbox, with the custom RDMA/RoCE cluster build. Recommended default for most users. |
+| `vllm-rocm-gfx1151` | Ubuntu 24.04 + official **stable** ROCm | latest stable release tag | **daily** (auto; rebuilds only when the version combo changes) | `:latest`, `:rocm<X>-torch<Y>-vllm<Z>`, `:<date>` | A reproducible build off the nightly treadmill. The version-stamped tag pins an exact, immutable ROCm/torch/vLLM combo. |
+| `vllm-rocm-gfx1151-nightly` | Ubuntu 24.04 + official stable ROCm | **bleeding-edge** vLLM `main` | manual only | `:latest`, `:<date-time>` | Trying brand-new model archs/features that need vLLM `main` before they reach a stable tag (e.g. block-diffusion DiffusionGemma). |
+
+> The two `vllm-rocm-*` (Ubuntu / stable-ROCm) images are currently published under the [`lafunamor`](https://hub.docker.com/u/lafunamor) namespace as a test-drive (see [PR #63](https://github.com/kyuz0/amd-strix-halo-vllm-toolboxes/pull/63)). Their build workflows derive the Docker Hub repo from the GitHub owner, so they would publish under `kyuz0/` automatically if merged upstream.
+
+Pin an exact, reproducible stack with the version-stamped tag, e.g.:
+
+```bash
+docker pull docker.io/lafunamor/vllm-rocm-gfx1151:rocm7.2.4-torch2.12.0-vllm0.23.0   # immutable combo
+docker pull docker.io/lafunamor/vllm-rocm-gfx1151:latest                            # most recent stable daily
+docker pull docker.io/lafunamor/vllm-rocm-gfx1151-nightly:latest                    # latest manual bleeding-edge build
+```
+
+---
 
 ## Tested Models (Benchmarks)
 

--- a/scripts/patch_amdsmi.py
+++ b/scripts/patch_amdsmi.py
@@ -1,0 +1,99 @@
+"""Workaround for an amdsmi bug: VRAM total is the BIOS carveout on APUs.
+
+On AMD APUs (e.g. gfx1151 / Strix Halo) amdsmi reports the small dedicated BIOS VRAM
+carveout as the VRAM total, instead of the memory the GPU actually addresses:
+
+    amdsmi VRAM total   ->     536,870,912   (0.50 GiB)   <- BIOS carveout
+    amdsmi GTT total    -> 118,111,600,640   (110.00 GiB) <- unified pool
+    KFD mem_banks/0     -> 118,111,600,640   (110.00 GiB) <- the driver's truth
+    HIP totalGlobalMem  -> 118,111,600,640   (110.00 GiB)
+
+sysfs `mem_info_vram_total` only exposes the carveout, and
+`rsmi_dev_memory_total_get()` only consults KFD when that read fails or returns 0 --
+on an APU it "succeeds" with the carveout, so KFD is never asked.
+
+Consumers that size a memory budget from the VRAM total therefore see 0.5 GiB on a
+110 GiB device. vLLM's ROCm platform does exactly this in
+`RocmPlatform.get_device_total_memory()`.
+
+The bug is in amdsmi, not in its consumers, so patch it here rather than in vLLM.
+This mirrors the fix proposed upstream (prefer the KFD/GTT total when it exceeds the
+sysfs VRAM total):
+
+    https://github.com/ROCm/rocm-systems/pull/8419   (APU case proposed in a comment)
+    https://github.com/ROCm/rocm-systems/issues/8476 (APUs aren't identifiable via amdsmi)
+
+Delete this script once the fix ships in a ROCm release. It is idempotent and a no-op
+if amdsmi already reports the correct total.
+"""
+
+import importlib.util
+import os
+import sys
+
+ANCHOR = """    _check_res(
+        amdsmi_wrapper.amdsmi_get_gpu_memory_total(
+            processor_handle, mem_type, ctypes.byref(total))
+    )
+
+    return total.value"""
+
+REPLACEMENT = """    _check_res(
+        amdsmi_wrapper.amdsmi_get_gpu_memory_total(
+            processor_handle, mem_type, ctypes.byref(total))
+    )
+
+    # --- Strix Halo / APU workaround (see scripts/patch_amdsmi.py) --------------
+    # On APUs the VRAM total is only the small BIOS carveout, while the GPU
+    # addresses the unified pool that the GTT total (and KFD mem_banks) reports.
+    # Prefer the larger of the two, mirroring the fix proposed upstream in
+    # ROCm/rocm-systems#8419. Remove once that ships in a ROCm release.
+    if mem_type == AmdSmiMemoryType.VRAM:
+        try:
+            _gtt = ctypes.c_uint64()
+            if (
+                amdsmi_wrapper.amdsmi_get_gpu_memory_total(
+                    processor_handle, AmdSmiMemoryType.GTT, ctypes.byref(_gtt)
+                )
+                == 0
+                and _gtt.value > total.value
+            ):
+                return _gtt.value
+        except Exception:  # never let the workaround break a working query
+            pass
+    # --- end workaround --------------------------------------------------------
+
+    return total.value"""
+
+MARKER = "Strix Halo / APU workaround"
+
+
+def main() -> int:
+    spec = importlib.util.find_spec("amdsmi")
+    if spec is None or not spec.origin:
+        print(" -> amdsmi not installed; nothing to patch", file=sys.stderr)
+        return 1
+
+    path = os.path.join(os.path.dirname(spec.origin), "amdsmi_interface.py")
+    txt = open(path).read()
+
+    if MARKER in txt:
+        print(" -> amdsmi already patched (idempotent no-op)")
+        return 0
+
+    if ANCHOR not in txt:
+        # amdsmi changed shape, or the upstream fix has landed and this is obsolete.
+        print(
+            " -> amdsmi_get_gpu_memory_total does not match the expected shape; "
+            "skipping (upstream fix may have landed -- verify and drop this script)",
+            file=sys.stderr,
+        )
+        return 1
+
+    open(path, "w").write(txt.replace(ANCHOR, REPLACEMENT, 1))
+    print(" -> Patched amdsmi_get_gpu_memory_total (APU: prefer GTT over VRAM carveout)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/patch_fp8_kernels.py
+++ b/scripts/patch_fp8_kernels.py
@@ -5,39 +5,54 @@ from pathlib import Path
 # Kernels: https://github.com/leonyurko/vllm-fp8-strix-halo-kernel-support
 # (the kernel modules — fp8_triton.py etc. — are placed on PYTHONPATH, e.g. /opt/fp8).
 #
-# gfx1151 has no native FP8 tensor support, so vLLM's compressed-tensors W8A8-FP8
-# path falls back to a slow generic GEMM. This routes the scaled-mm call through
-# leonyurko's fused FP8->bf16 Triton dequant-GEMM (fp8_triton.fp8_gemm).
+# gfx1151 has no native FP8 tensor support. This injects a routing shim into vLLM's
+# compressed-tensors W8A8-FP8 scaled-mm path that *optionally* uses @leonyurko's fused
+# FP8->bf16 Triton dequant-GEMM (fp8_triton.fp8_gemm).
+#
+# OPT-IN: the shim only routes to the Triton kernel when the env var
+# VLLM_STRIX_FP8_TRITON=1 is set at serve time; otherwise it calls the stock
+# torch._scaled_mm (upstream behavior unchanged). This keeps the kernels off the
+# default path — they override stock/hipBLASLt FP8, require --enforce-eager +
+# VLLM_ROCM_USE_AITER=0, and aren't benchmarked — so they're only used when
+# consciously activated (per kyuz0's suggestion on #67).
 #
 # Deliberately a SEPARATE patch file (NOT patch_strix.py) so the FP8 work stays
-# independent of the is_integrated memory PR (#66) and can be merged in any order.
-# Surgical call-swap (not a file overlay): preserves vLLM's current scale-handling
-# in apply_scaled_mm, only redirecting the GEMM call. No-ops if already applied.
+# independent of the is_integrated memory PR (#66). Surgical call-swap (not a file
+# overlay): preserves vLLM's current scale-handling in apply_scaled_mm, only
+# redirecting the GEMM call. No-ops if already applied.
 
 SCALED_MM_FB = '''
 
+import os as _os
+_VLLM_STRIX_FP8_TRITON = _os.environ.get("VLLM_STRIX_FP8_TRITON") == "1"
+
+
 def _scaled_mm_fb(A, B, *, out_dtype, scale_a, scale_b, bias=None):
-    # gfx1151: fused FP8->bf16 Triton dequant GEMM (weights stay FP8 in HBM).
-    # From leonyurko/vllm-fp8-strix-halo-kernel-support; fp8_triton on PYTHONPATH.
-    # Falls back to a bf16 matmul + manual dequant if the kernel is unavailable.
+    # Default: stock torch._scaled_mm (upstream behavior, incl. any hipBLASLt FP8).
+    # Opt-in (VLLM_STRIX_FP8_TRITON=1): gfx1151 fused FP8->bf16 Triton dequant GEMM
+    # from leonyurko/vllm-fp8-strix-halo-kernel-support (fp8_triton on PYTHONPATH),
+    # with a bf16 matmul + manual dequant fallback if the kernel is unavailable.
+    if not _VLLM_STRIX_FP8_TRITON:
+        return torch._scaled_mm(
+            A, B, out_dtype=out_dtype, scale_a=scale_a, scale_b=scale_b, bias=bias
+        )
     try:
         from fp8_triton import fp8_gemm
         return fp8_gemm(A.contiguous(), B, scale_a, scale_b, out_dtype, bias)
     except Exception:
-        import torch as _t
-        o = (A.to(_t.bfloat16) @ B.to(_t.bfloat16)).to(_t.float32)
-        sa = scale_a.to(_t.float32).reshape(-1)
-        sb = scale_b.to(_t.float32).reshape(-1)
+        o = (A.to(torch.bfloat16) @ B.to(torch.bfloat16)).to(torch.float32)
+        sa = scale_a.to(torch.float32).reshape(-1)
+        sb = scale_b.to(torch.float32).reshape(-1)
         o = o * (sa if sa.numel() == 1 else sa.view(-1, 1))
         o = o * (sb if sb.numel() == 1 else sb.view(1, -1))
         if bias is not None:
-            o = o + bias.to(_t.float32)
+            o = o + bias.to(torch.float32)
         return o.to(out_dtype)
 '''
 
 
 def patch_fp8():
-    print("Applying Strix Halo FP8 Triton kernel routing to vLLM...")
+    print("Applying Strix Halo FP8 Triton kernel routing to vLLM (opt-in via VLLM_STRIX_FP8_TRITON)...")
     p = Path('vllm/model_executor/kernels/linear/scaled_mm/pytorch.py')
     if not p.exists():
         print(" -> FP8 patch: scaled_mm/pytorch.py not found; skipping (vLLM layout changed?)")
@@ -50,13 +65,13 @@ def patch_fp8():
     if n == 0:
         print(" -> FP8 patch: no 'output = torch._scaled_mm(' call sites found; skipping")
         return
-    # 1) redirect the apply_scaled_mm GEMM calls to the Triton kernel
+    # 1) redirect the apply_scaled_mm GEMM calls through the opt-in shim
     txt = txt.replace('output = torch._scaled_mm(', 'output = _scaled_mm_fb(')
-    # 2) inject the routing function at module scope (called at runtime)
+    # 2) inject the routing shim at module scope (reads the env var once at import)
     txt = txt + SCALED_MM_FB
     p.write_text(txt)
-    print(f" -> FP8 patch: routed {n} scaled_mm call site(s) to fp8_triton + injected _scaled_mm_fb")
-    print("Successfully patched vLLM for Strix Halo FP8 kernels.")
+    print(f" -> FP8 patch: routed {n} scaled_mm call site(s) via _scaled_mm_fb (opt-in: VLLM_STRIX_FP8_TRITON=1)")
+    print("Successfully patched vLLM for Strix Halo FP8 kernels (opt-in).")
 
 
 if __name__ == '__main__':

--- a/scripts/patch_fp8_kernels.py
+++ b/scripts/patch_fp8_kernels.py
@@ -1,0 +1,63 @@
+import sys
+from pathlib import Path
+
+# FP8 (W8A8) Strix Halo kernel routing for vLLM.
+# Kernels: https://github.com/leonyurko/vllm-fp8-strix-halo-kernel-support
+# (the kernel modules — fp8_triton.py etc. — are placed on PYTHONPATH, e.g. /opt/fp8).
+#
+# gfx1151 has no native FP8 tensor support, so vLLM's compressed-tensors W8A8-FP8
+# path falls back to a slow generic GEMM. This routes the scaled-mm call through
+# leonyurko's fused FP8->bf16 Triton dequant-GEMM (fp8_triton.fp8_gemm).
+#
+# Deliberately a SEPARATE patch file (NOT patch_strix.py) so the FP8 work stays
+# independent of the is_integrated memory PR (#66) and can be merged in any order.
+# Surgical call-swap (not a file overlay): preserves vLLM's current scale-handling
+# in apply_scaled_mm, only redirecting the GEMM call. No-ops if already applied.
+
+SCALED_MM_FB = '''
+
+def _scaled_mm_fb(A, B, *, out_dtype, scale_a, scale_b, bias=None):
+    # gfx1151: fused FP8->bf16 Triton dequant GEMM (weights stay FP8 in HBM).
+    # From leonyurko/vllm-fp8-strix-halo-kernel-support; fp8_triton on PYTHONPATH.
+    # Falls back to a bf16 matmul + manual dequant if the kernel is unavailable.
+    try:
+        from fp8_triton import fp8_gemm
+        return fp8_gemm(A.contiguous(), B, scale_a, scale_b, out_dtype, bias)
+    except Exception:
+        import torch as _t
+        o = (A.to(_t.bfloat16) @ B.to(_t.bfloat16)).to(_t.float32)
+        sa = scale_a.to(_t.float32).reshape(-1)
+        sb = scale_b.to(_t.float32).reshape(-1)
+        o = o * (sa if sa.numel() == 1 else sa.view(-1, 1))
+        o = o * (sb if sb.numel() == 1 else sb.view(1, -1))
+        if bias is not None:
+            o = o + bias.to(_t.float32)
+        return o.to(out_dtype)
+'''
+
+
+def patch_fp8():
+    print("Applying Strix Halo FP8 Triton kernel routing to vLLM...")
+    p = Path('vllm/model_executor/kernels/linear/scaled_mm/pytorch.py')
+    if not p.exists():
+        print(" -> FP8 patch: scaled_mm/pytorch.py not found; skipping (vLLM layout changed?)")
+        return
+    txt = p.read_text()
+    if '_scaled_mm_fb' in txt:
+        print(" -> FP8 patch: already applied; skipping")
+        return
+    n = txt.count('output = torch._scaled_mm(')
+    if n == 0:
+        print(" -> FP8 patch: no 'output = torch._scaled_mm(' call sites found; skipping")
+        return
+    # 1) redirect the apply_scaled_mm GEMM calls to the Triton kernel
+    txt = txt.replace('output = torch._scaled_mm(', 'output = _scaled_mm_fb(')
+    # 2) inject the routing function at module scope (called at runtime)
+    txt = txt + SCALED_MM_FB
+    p.write_text(txt)
+    print(f" -> FP8 patch: routed {n} scaled_mm call site(s) to fp8_triton + injected _scaled_mm_fb")
+    print("Successfully patched vLLM for Strix Halo FP8 kernels.")
+
+
+if __name__ == '__main__':
+    patch_fp8()

--- a/scripts/patch_strix.py
+++ b/scripts/patch_strix.py
@@ -52,6 +52,19 @@ def patch_vllm():
             txt = txt.replace('def _get_gcn_arch() -> str:', 'def _get_gcn_arch() -> str:\n    return "gfx1151"\n\ndef _old_get_gcn_arch() -> str:')
             txt = re.sub(r'device_type = .*', 'device_type = "rocm"', txt)
             txt = re.sub(r'device_name = .*', 'device_name = "gfx1151"', txt)
+        # Patch 1.5b: force the torch.cuda fallback in get_device_total_memory().
+        # amdsmi is stubbed as a MagicMock above, so _query_total_memory_from_amdsmi()
+        # returns a MagicMock (a mock call never raises) — get_device_total_memory() then
+        # returns that MagicMock instead of hitting its torch.cuda fallback. vLLM >=0.25.1's
+        # new get_batch_defaults() calls it at engine-config time and does
+        # `device_memory >= 70*GiB`, which throws `TypeError: '>=' MagicMock vs int` and
+        # crashes startup for EVERY model. Make the amdsmi path raise so the existing
+        # `return torch.cuda.get_device_properties(...).total_memory` (a real int) is used.
+        if 'return _query_total_memory_from_amdsmi(physical_device_id)' in txt:
+            txt = txt.replace(
+                'return _query_total_memory_from_amdsmi(physical_device_id)',
+                'raise RuntimeError("amdsmi stubbed on Strix Halo; use torch.cuda fallback")')
+            print(" -> Patched get_device_total_memory (force torch.cuda fallback; fixes vLLM 0.25.1 MagicMock crash)")
         p_rocm_plat.write_text(txt)
         print(" -> Patched vllm/platforms/rocm.py (MagicMock amdsmi + forced gfx1151)")
 

--- a/scripts/patch_strix.py
+++ b/scripts/patch_strix.py
@@ -24,49 +24,28 @@ def patch_vllm():
             p_spinloop.write_text(txt)
             print(" -> Patched csrc/spinloop.cpp (mwaitxintrin.h -> x86intrin.h for clang)")
 
-    # Patch 1: vllm/platforms/__init__.py (amdsmi monkey patch — PROVEN working for 5 months)
-    # Comment out real amdsmi imports and replace with pass stubs.
-    # The actual amdsmi library doesn't work on Strix Halo APUs in containers.
-    p_init = Path('vllm/platforms/__init__.py')
-    if p_init.exists():
-        txt = p_init.read_text()
-        txt = txt.replace('import amdsmi', '# import amdsmi')
-        txt = re.sub(r'is_rocm = .*', 'is_rocm = True', txt)
-        txt = re.sub(r'if len\(amdsmi\.amdsmi_get_processor_handles\(\)\) > 0:', 'if True:', txt)
-        txt = txt.replace('amdsmi.amdsmi_init()', 'pass')
-        txt = txt.replace('amdsmi.amdsmi_shut_down()', 'pass')
-        p_init.write_text(txt)
-        print(" -> Patched vllm/platforms/__init__.py (amdsmi disabled, is_rocm forced True)")
-
-    # Patch 1.5: vllm/platforms/rocm.py (MagicMock amdsmi + force gfx1151)
-    # Prepend MagicMock so any remaining amdsmi references in rocm.py silently succeed.
-    p_rocm_plat = Path('vllm/platforms/rocm.py')
-    if p_rocm_plat.exists():
-        txt = p_rocm_plat.read_text()
-        # Add MagicMock header if not already present
-        if 'sys.modules["amdsmi"] = MagicMock()' not in txt:
-            header = 'import sys\nfrom unittest.mock import MagicMock\nsys.modules["amdsmi"] = MagicMock()\n'
-            txt = header + txt
-        # Force arch detection
-        if 'def _get_gcn_arch() -> str:\n    return "gfx1151"' not in txt:
-            txt = txt.replace('def _get_gcn_arch() -> str:', 'def _get_gcn_arch() -> str:\n    return "gfx1151"\n\ndef _old_get_gcn_arch() -> str:')
-            txt = re.sub(r'device_type = .*', 'device_type = "rocm"', txt)
-            txt = re.sub(r'device_name = .*', 'device_name = "gfx1151"', txt)
-        # Patch 1.5b: force the torch.cuda fallback in get_device_total_memory().
-        # amdsmi is stubbed as a MagicMock above, so _query_total_memory_from_amdsmi()
-        # returns a MagicMock (a mock call never raises) — get_device_total_memory() then
-        # returns that MagicMock instead of hitting its torch.cuda fallback. vLLM >=0.25.1's
-        # new get_batch_defaults() calls it at engine-config time and does
-        # `device_memory >= 70*GiB`, which throws `TypeError: '>=' MagicMock vs int` and
-        # crashes startup for EVERY model. Make the amdsmi path raise so the existing
-        # `return torch.cuda.get_device_properties(...).total_memory` (a real int) is used.
-        if 'return _query_total_memory_from_amdsmi(physical_device_id)' in txt:
-            txt = txt.replace(
-                'return _query_total_memory_from_amdsmi(physical_device_id)',
-                'raise RuntimeError("amdsmi stubbed on Strix Halo; use torch.cuda fallback")')
-            print(" -> Patched get_device_total_memory (force torch.cuda fallback; fixes vLLM 0.25.1 MagicMock crash)")
-        p_rocm_plat.write_text(txt)
-        print(" -> Patched vllm/platforms/rocm.py (MagicMock amdsmi + forced gfx1151)")
+    # NOTE: the former Patch 1 / Patch 1.5 (comment out `import amdsmi`, stub it with a
+    # MagicMock, and force the GCN arch to gfx1151) are GONE.
+    #
+    # They existed because "the actual amdsmi library doesn't work on Strix Halo APUs in
+    # containers". That is no longer true: the amdsmi python bindings ship with ROCm
+    # (/opt/rocm/share/amd_smi) and work fine on gfx1151 -- they were simply never
+    # installed, so `from amdsmi import ...` failed and everything had to be stubbed.
+    # The Dockerfile now installs them, and vLLM resolves the arch and device name on its
+    # own (verified on hardware: _query_gcn_arch_from_amdsmi() -> 'gfx1151',
+    # get_device_name() -> AMD_Radeon_8060S, 40 CUs).
+    #
+    # Keeping the MagicMock was also actively harmful: a mock call never raises, so vLLM's
+    # `try: <amdsmi> except: <fallback>` helpers never reached their fallback and the mock
+    # leaked into real use. vLLM >= 0.25.1 calls get_device_total_memory() from
+    # get_batch_defaults() at engine-config time and evaluates `device_memory >= 70*GiB`,
+    # which raised `TypeError: '>=' not supported between MagicMock and int` and crashed
+    # startup for EVERY model.
+    #
+    # The one genuine bug left is in amdsmi itself (on APUs it reports the 512 MiB BIOS
+    # VRAM carveout as the VRAM total instead of the 110 GiB unified pool). That is worked
+    # around in scripts/patch_amdsmi.py -- at the layer where the bug actually is -- so
+    # vLLM needs no memory patch at all. Proposed upstream: ROCm/rocm-systems#8419.
 
     # Patch 2: _aiter_ops.py (Enable AITER on gfx1x, disable FP8 linear)
     p_aiter = Path('vllm/_aiter_ops.py')


### PR DESCRIPTION
Adds a parallel `Dockerfile.ubuntu`; the existing Fedora build is untouched.

## Why switch base?

#61 is the symptom: the toolbox tracks **TheRock nightlies** (ROCm SDK tarball + nightly torch), and a bad nightly (torch 0612, [TheRock#5763](https://github.com/ROCm/TheRock/issues/5763)) makes the image DOA on gfx1151. The root reason we were on nightlies at all was that **gfx1151 used to be nightly-only**. That is no longer true:

- Official **ROCm 7.2.4** rocBLAS ships `gfx1151` Tensile kernels, and `hipcc --offload-arch=gfx1151` compiles cleanly (verified in `rocm/dev-ubuntu-24.04:7.2.4-complete`).
- The **stable** PyTorch ROCm wheel (`download.pytorch.org/whl/rocm7.2`, torch 2.12) has `gfx1151` in its `get_arch_list()` and runs on a real 8060S.

So gfx1151 is now first-class in *stable* ROCm — we can leave the nightly channel for the stable track. Fedora can't do this (no official ROCm packages for Fedora; that's why TheRock was needed), so "official stable" implies an Ubuntu (or RHEL) base — hence this greenfield.

## What this Dockerfile does

`FROM rocm/dev-ubuntu-24.04:7.2.4-complete` (AMD's own official ROCm SDK image) → minimal `apt` deps → stable torch wheel → build vLLM from source against the official `/opt/rocm`. No TheRock tarball, no nightly pins, no `lib/lib64` merge hack.

## Validated end-to-end on gfx1151 (Framework Desktop, Ryzen AI Max+ 395)

- vLLM `eb28452b1` **compiles** against official ROCm 7.2.4 (wheel tagged `...rocm724...`).
- Serves **`cyankiwi/Qwen3.6-27B-AWQ-INT4`** (compressed-tensors W4A16 via `TritonW4A16LinearKernel`, + MTP).
- Serves **`google/diffusiongemma-26B-A4B-it`** (text + vision).

## Benefits
- **Off the nightly treadmill** — reproducible, no random nightly breakage (#61).
- AMD-blessed combo (it's the base of AMD's own `rocm/pytorch` images).
- Simpler: drops the TheRock tarball fetch, the nightly torch pin, and the Fedora `lib64` merge step.
- Python 3.12 native on 24.04.

## Downsides (the honest part — worth discussing)
- **Image size: ~49.5 GB vs ~35.3 GB** for the current TheRock-based image (**+14 GB / ~40%**), even though this greenfield *also* drops AITER. The official `…-complete` SDK base carries a lot we don't strictly need at runtime. Mitigable with a multi-stage build (copy only the runtime ROCm libs into a slim final image), but that's extra work and not done here.
- **Freshness:** official 7.2.4 lags TheRock's 7.14 nightly. New models/vLLM features needing bleeding-edge ROCm won't be available on the stable track. → suggests a **dual-track** layout (this stable base for production + a nightly track for testing new features), switchable by build-arg.
- **OS migration:** Fedora→Ubuntu touches the package layer (mechanical) and changes the base you maintain/test against.

## Scope notes
- This greenfield also omits the custom **flash-attn/AITER** build — that's a *separate* axis with its own rationale and validation in #62; please discuss AITER there, not here, so the base-OS question stays clean.
- Draft on purpose — Id like to use this PR / #61 to discuss whether the Ubuntu+stable direction (and/or dual-track) is something you want, before polishing it (slimming the image, dual-track build-args, README, CI).