### PR TITLE
RFC: integrate @leonyurko's FP8 Strix Halo Triton kernels (#67)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -90,6 +90,21 @@ RUN if [ -n "$VLLM_COMMIT" ]; then \
 COPY scripts/patch_strix.py /opt/vllm/patch_strix.py
 RUN python /opt/vllm/patch_strix.py
 
+# --- FP8 (W8A8) Strix Halo Triton kernels (EXPERIMENTAL / RFC — see issue #67) ---
+# Custom FP8 kernels by @leonyurko for gfx1151 (which has no native FP8). The kernel
+# modules live on PYTHONPATH (/opt/fp8); patch_fp8_kernels.py routes vLLM's
+# compressed-tensors W8A8-FP8 scaled-mm path through the fused Triton dequant-GEMM
+# (fp8_triton.fp8_gemm). Kept separate from patch_strix.py so it stays independent
+# of the is_integrated memory work. Serve FP8 models with VLLM_ROCM_USE_AITER=0 and
+# --enforce-eager (see the kernel repo's serve scripts).
+# https://github.com/leonyurko/vllm-fp8-strix-halo-kernel-support
+ARG FP8_KERNELS_REF=50424f5525b8382353551e3301d0da56eca0be2b
+RUN git clone https://github.com/leonyurko/vllm-fp8-strix-halo-kernel-support.git /opt/fp8 && \
+  cd /opt/fp8 && git checkout "$FP8_KERNELS_REF"
+COPY scripts/patch_fp8_kernels.py /opt/vllm/patch_fp8_kernels.py
+RUN python /opt/vllm/patch_fp8_kernels.py
+ENV PYTHONPATH=/opt/fp8
+
 # 7. Build vLLM (Wheel Method) with CLANG Host Compiler
 ENV ROCM_HOME="/opt/rocm"
 ENV HIP_PATH="/opt/rocm"

--- a/scripts/models.py
+++ b/scripts/models.py
@@ -11,7 +11,25 @@ MODEL_TABLE = {
             "--tool-call-parser", "llama3_json",
         ]
     },
-    
+
+    # EXPERIMENTAL — FP8 (W8A8) via @leonyurko's Strix Halo Triton kernels (#67).
+    # The "env" VLLM_STRIX_FP8_TRITON=1 opts this model into the patched fp8_triton
+    # path (default-off; without it FP8 uses stock torch._scaled_mm). The kernels
+    # require VLLM_ROCM_USE_AITER=0 + enforce_eager. Correctness-verified on gfx1151,
+    # not yet benchmarked.
+    "RedHatAI/Meta-Llama-3.1-8B-Instruct-FP8-dynamic": {
+        "trust_remote": False,
+        "valid_tp": [1],
+        "enforce_eager": True,
+        "env": {"VLLM_STRIX_FP8_TRITON": "1", "VLLM_ROCM_USE_AITER": "0"},
+        "max_num_seqs": "64",
+        "max_tokens": "32768",
+        "extra_flags": [
+            "--enable-auto-tool-choice",
+            "--tool-call-parser", "llama3_json",
+        ]
+    },
+
     "google/gemma-4-26B-A4B-it": {
         "trust_remote": False,
         "enforce_eager": False,

--- a/scripts/patch_fp8_kernels.py
+++ b/scripts/patch_fp8_kernels.py
@@ -5,39 +5,54 @@ from pathlib import Path
 # Kernels: https://github.com/leonyurko/vllm-fp8-strix-halo-kernel-support
 # (the kernel modules — fp8_triton.py etc. — are placed on PYTHONPATH, e.g. /opt/fp8).
 #
-# gfx1151 has no native FP8 tensor support, so vLLM's compressed-tensors W8A8-FP8
-# path falls back to a slow generic GEMM. This routes the scaled-mm call through
-# leonyurko's fused FP8->bf16 Triton dequant-GEMM (fp8_triton.fp8_gemm).
+# gfx1151 has no native FP8 tensor support. This injects a routing shim into vLLM's
+# compressed-tensors W8A8-FP8 scaled-mm path that *optionally* uses @leonyurko's fused
+# FP8->bf16 Triton dequant-GEMM (fp8_triton.fp8_gemm).
+#
+# OPT-IN: the shim only routes to the Triton kernel when the env var
+# VLLM_STRIX_FP8_TRITON=1 is set at serve time; otherwise it calls the stock
+# torch._scaled_mm (upstream behavior unchanged). This keeps the kernels off the
+# default path — they override stock/hipBLASLt FP8, require --enforce-eager +
+# VLLM_ROCM_USE_AITER=0, and aren't benchmarked — so they're only used when
+# consciously activated (per kyuz0's suggestion on #67).
 #
 # Deliberately a SEPARATE patch file (NOT patch_strix.py) so the FP8 work stays
-# independent of the is_integrated memory PR (#66) and can be merged in any order.
-# Surgical call-swap (not a file overlay): preserves vLLM's current scale-handling
-# in apply_scaled_mm, only redirecting the GEMM call. No-ops if already applied.
+# independent of the is_integrated memory PR (#66). Surgical call-swap (not a file
+# overlay): preserves vLLM's current scale-handling in apply_scaled_mm, only
+# redirecting the GEMM call. No-ops if already applied.
 
 SCALED_MM_FB = '''
 
+import os as _os
+_VLLM_STRIX_FP8_TRITON = _os.environ.get("VLLM_STRIX_FP8_TRITON") == "1"
+
+
 def _scaled_mm_fb(A, B, *, out_dtype, scale_a, scale_b, bias=None):
-    # gfx1151: fused FP8->bf16 Triton dequant GEMM (weights stay FP8 in HBM).
-    # From leonyurko/vllm-fp8-strix-halo-kernel-support; fp8_triton on PYTHONPATH.
-    # Falls back to a bf16 matmul + manual dequant if the kernel is unavailable.
+    # Default: stock torch._scaled_mm (upstream behavior, incl. any hipBLASLt FP8).
+    # Opt-in (VLLM_STRIX_FP8_TRITON=1): gfx1151 fused FP8->bf16 Triton dequant GEMM
+    # from leonyurko/vllm-fp8-strix-halo-kernel-support (fp8_triton on PYTHONPATH),
+    # with a bf16 matmul + manual dequant fallback if the kernel is unavailable.
+    if not _VLLM_STRIX_FP8_TRITON:
+        return torch._scaled_mm(
+            A, B, out_dtype=out_dtype, scale_a=scale_a, scale_b=scale_b, bias=bias
+        )
     try:
         from fp8_triton import fp8_gemm
         return fp8_gemm(A.contiguous(), B, scale_a, scale_b, out_dtype, bias)
     except Exception:
-        import torch as _t
-        o = (A.to(_t.bfloat16) @ B.to(_t.bfloat16)).to(_t.float32)
-        sa = scale_a.to(_t.float32).reshape(-1)
-        sb = scale_b.to(_t.float32).reshape(-1)
+        o = (A.to(torch.bfloat16) @ B.to(torch.bfloat16)).to(torch.float32)
+        sa = scale_a.to(torch.float32).reshape(-1)
+        sb = scale_b.to(torch.float32).reshape(-1)
         o = o * (sa if sa.numel() == 1 else sa.view(-1, 1))
         o = o * (sb if sb.numel() == 1 else sb.view(1, -1))
         if bias is not None:
-            o = o + bias.to(_t.float32)
+            o = o + bias.to(torch.float32)
         return o.to(out_dtype)
 '''
 
 
 def patch_fp8():
-    print("Applying Strix Halo FP8 Triton kernel routing to vLLM...")
+    print("Applying Strix Halo FP8 Triton kernel routing to vLLM (opt-in via VLLM_STRIX_FP8_TRITON)...")
     p = Path('vllm/model_executor/kernels/linear/scaled_mm/pytorch.py')
     if not p.exists():
         print(" -> FP8 patch: scaled_mm/pytorch.py not found; skipping (vLLM layout changed?)")
@@ -50,13 +65,13 @@ def patch_fp8():
     if n == 0:
         print(" -> FP8 patch: no 'output = torch._scaled_mm(' call sites found; skipping")
         return
-    # 1) redirect the apply_scaled_mm GEMM calls to the Triton kernel
+    # 1) redirect the apply_scaled_mm GEMM calls through the opt-in shim
     txt = txt.replace('output = torch._scaled_mm(', 'output = _scaled_mm_fb(')
-    # 2) inject the routing function at module scope (called at runtime)
+    # 2) inject the routing shim at module scope (reads the env var once at import)
     txt = txt + SCALED_MM_FB
     p.write_text(txt)
-    print(f" -> FP8 patch: routed {n} scaled_mm call site(s) to fp8_triton + injected _scaled_mm_fb")
-    print("Successfully patched vLLM for Strix Halo FP8 kernels.")
+    print(f" -> FP8 patch: routed {n} scaled_mm call site(s) via _scaled_mm_fb (opt-in: VLLM_STRIX_FP8_TRITON=1)")
+    print("Successfully patched vLLM for Strix Halo FP8 kernels (opt-in).")
 
 
 if __name__ == '__main__':

--- a/scripts/patch_fp8_kernels.py
+++ b/scripts/patch_fp8_kernels.py
@@ -1,0 +1,63 @@
+import sys
+from pathlib import Path
+
+# FP8 (W8A8) Strix Halo kernel routing for vLLM.
+# Kernels: https://github.com/leonyurko/vllm-fp8-strix-halo-kernel-support
+# (the kernel modules — fp8_triton.py etc. — are placed on PYTHONPATH, e.g. /opt/fp8).
+#
+# gfx1151 has no native FP8 tensor support, so vLLM's compressed-tensors W8A8-FP8
+# path falls back to a slow generic GEMM. This routes the scaled-mm call through
+# leonyurko's fused FP8->bf16 Triton dequant-GEMM (fp8_triton.fp8_gemm).
+#
+# Deliberately a SEPARATE patch file (NOT patch_strix.py) so the FP8 work stays
+# independent of the is_integrated memory PR (#66) and can be merged in any order.
+# Surgical call-swap (not a file overlay): preserves vLLM's current scale-handling
+# in apply_scaled_mm, only redirecting the GEMM call. No-ops if already applied.
+
+SCALED_MM_FB = '''
+
+def _scaled_mm_fb(A, B, *, out_dtype, scale_a, scale_b, bias=None):
+    # gfx1151: fused FP8->bf16 Triton dequant GEMM (weights stay FP8 in HBM).
+    # From leonyurko/vllm-fp8-strix-halo-kernel-support; fp8_triton on PYTHONPATH.
+    # Falls back to a bf16 matmul + manual dequant if the kernel is unavailable.
+    try:
+        from fp8_triton import fp8_gemm
+        return fp8_gemm(A.contiguous(), B, scale_a, scale_b, out_dtype, bias)
+    except Exception:
+        import torch as _t
+        o = (A.to(_t.bfloat16) @ B.to(_t.bfloat16)).to(_t.float32)
+        sa = scale_a.to(_t.float32).reshape(-1)
+        sb = scale_b.to(_t.float32).reshape(-1)
+        o = o * (sa if sa.numel() == 1 else sa.view(-1, 1))
+        o = o * (sb if sb.numel() == 1 else sb.view(1, -1))
+        if bias is not None:
+            o = o + bias.to(_t.float32)
+        return o.to(out_dtype)
+'''
+
+
+def patch_fp8():
+    print("Applying Strix Halo FP8 Triton kernel routing to vLLM...")
+    p = Path('vllm/model_executor/kernels/linear/scaled_mm/pytorch.py')
+    if not p.exists():
+        print(" -> FP8 patch: scaled_mm/pytorch.py not found; skipping (vLLM layout changed?)")
+        return
+    txt = p.read_text()
+    if '_scaled_mm_fb' in txt:
+        print(" -> FP8 patch: already applied; skipping")
+        return
+    n = txt.count('output = torch._scaled_mm(')
+    if n == 0:
+        print(" -> FP8 patch: no 'output = torch._scaled_mm(' call sites found; skipping")
+        return
+    # 1) redirect the apply_scaled_mm GEMM calls to the Triton kernel
+    txt = txt.replace('output = torch._scaled_mm(', 'output = _scaled_mm_fb(')
+    # 2) inject the routing function at module scope (called at runtime)
+    txt = txt + SCALED_MM_FB
+    p.write_text(txt)
+    print(f" -> FP8 patch: routed {n} scaled_mm call site(s) to fp8_triton + injected _scaled_mm_fb")
+    print("Successfully patched vLLM for Strix Halo FP8 kernels.")
+
+
+if __name__ == '__main__':
+    patch_fp8()


### PR DESCRIPTION
Toward #67 — bakes @leonyurko's FP8 kernels into the image so they can be tested without bind-mounts.

## What
gfx1151 has no native FP8, so compressed-tensors **W8A8-FP8** falls back to a slow generic GEMM. This routes it through @leonyurko's fused FP8→bf16 Triton dequant-GEMM ([vllm-fp8-strix-halo-kernel-support](https://github.com/leonyurko/vllm-fp8-strix-halo-kernel-support)).

## How (2 pieces, both additive)
- **`Dockerfile`**: clone the kernel repo (pinned `FP8_KERNELS_REF`) → `/opt/fp8` + `ENV PYTHONPATH=/opt/fp8` so `fp8_triton` is importable at runtime.
- **`scripts/patch_fp8_kernels.py`** (new, *separate* from `patch_strix.py`): surgically swaps the 3 `apply_scaled_mm` GEMM calls (`torch._scaled_mm` → `_scaled_mm_fb` → `fp8_triton.fp8_gemm`, with a bf16 fallback). It is a **call-swap, not a file overlay**, so it preserves vLLM's current scale-handling (your `pytorch.py` has scale-reshape logic that @leonyurko's 0.19.2rc1-pinned `pytorch_patched.py` predates). Idempotent.

## Notes
- A dedicated patch file means this does **not** touch `patch_strix.py`, so it's independent of the memory/`is_integrated` work and merges in any order.
- Excludes @leonyurko's `rocm_patched.py` (that's the memory-reporting fix, separate concern).
- Serve FP8 models with `VLLM_ROCM_USE_AITER=0` + `--enforce-eager` (not baked globally — that would disable AITER for non-FP8 models).

## Status
**Untested RFC.** Validated only that the patch applies to current vLLM `scaled_mm/pytorch.py` and compiles (3 call sites routed). Not yet run end-to-end with an FP8 model — happy to validate on gfx1151 once it builds, and @leonyurko / @kyuz0 can exercise it. cc @leonyurko