### PR TITLE
Ubuntu + official-release ROCm gfx1151 vLLM image (off the nightly treadmill, with vision)

### DIFF
--- a/.github/workflows/build-ubuntu-stable.yml
+++ b/.github/workflows/build-ubuntu-stable.yml
@@ -1,0 +1,188 @@
+name: build-ubuntu-stable
+
+# Ubuntu + STABLE ROCm/torch (repo.amd.com per-arch gfx1151 wheels) vLLM image, WITH vision.
+# Publishes docker.io/<owner>/vllm-rocm-gfx1151. Replaces the two former Ubuntu images
+# (old dev-ubuntu base + the nightly variant) — see Dockerfile.ubuntu-repoamd.
+#
+# Off the nightly treadmill: the whole gfx1151 ROCm/torch stack is STABLE per-arch wheels
+# from https://repo.amd.com/rocm/whl/gfx1151/ (torch X.Y.Z+rocmA.B.C, release — not alpha).
+# torch brings its own matched ROCm -> no system-vs-pip ABI mismatch. Vision works via a
+# ROCm flash-attention + aiter build (ViT Flash Attention, not the SDPA path that OOMs).
+# First serve of a model autotunes the Triton GDN+ViT kernels on the GPU (a few min); mount a
+# persistent host dir at TRITON_CACHE_DIR (/opt/triton_cache) to keep that cache across runs.
+#
+# DAILY cron auto-resolves the newest stable gfx1151 torch + latest vLLM stable tag and
+# rebuilds only when the resolved combo changed (immutable tag -> registry hit = no-op).
+
+on:
+  schedule:
+    - cron: "0 6 * * *"   # daily 06:00 UTC
+  workflow_dispatch:
+    inputs:
+      vllm_ref:
+        description: "vLLM tag/commit to build (empty = latest stable release tag)"
+        required: false
+        default: ""
+      force:
+        description: "Rebuild even if the version tag already exists"
+        type: boolean
+        required: false
+        default: false
+
+env:
+  DOCKER_BUILDKIT: "1"
+  ROCM_WHL: https://repo.amd.com/rocm/whl/gfx1151/
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Resolve image repo (from owner)
+        id: repo
+        run: |
+          set -euo pipefail
+          OWNER=$(echo "${{ github.repository_owner }}" | tr '[:upper:]' '[:lower:]')
+          REPO="${OWNER}/vllm-rocm-gfx1151"
+          echo "Image repo: docker.io/${REPO}"
+          echo "repo=${REPO}" >> "$GITHUB_OUTPUT"
+
+      - name: Resolve latest versions
+        id: ver
+        run: |
+          set -euo pipefail
+          # Newest STABLE gfx1151 torch on repo.amd.com (release build, e.g. 2.11.0+rocm7.13.0).
+          LATEST=$(curl -fsSL "${ROCM_WHL}torch/" \
+            | grep -oE 'torch-[0-9][0-9.]*\+rocm[0-9.]+-cp312-cp312-linux' \
+            | sed -E 's/^torch-//; s/-cp312-cp312-linux$//' \
+            | sort -V | tail -n1)
+          TORCH_VER="${LATEST%%+*}"        # 2.11.0
+          ROCM_VER="${LATEST##*+rocm}"     # 7.13.0
+          # vLLM: manual override, else latest stable release tag (skip rc/dev/a/b).
+          VLLM_REF="${{ github.event.inputs.vllm_ref }}"
+          if [ -z "$VLLM_REF" ]; then
+            VLLM_REF=$(git ls-remote --tags --refs https://github.com/vllm-project/vllm.git \
+              | awk '{print $2}' | sed 's#refs/tags/##' \
+              | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' \
+              | sort -V | tail -n1)
+          fi
+          if [ -z "$TORCH_VER" ] || [ -z "$ROCM_VER" ] || [ -z "$VLLM_REF" ]; then
+            echo "Failed to resolve: torch='$TORCH_VER' rocm='$ROCM_VER' vllm='$VLLM_REF'" >&2
+            exit 1
+          fi
+          VLLM_SLUG=$(echo "${VLLM_REF#v}" | sed 's/[^A-Za-z0-9._-]/-/g' | cut -c1-24)
+          VERSION_TAG="rocm${ROCM_VER}-torch${TORCH_VER}-vllm${VLLM_SLUG}"
+          echo "torch_ver=${TORCH_VER}"     >> "$GITHUB_OUTPUT"
+          echo "rocm_ver=${ROCM_VER}"       >> "$GITHUB_OUTPUT"
+          echo "vllm_ref=${VLLM_REF}"       >> "$GITHUB_OUTPUT"
+          echo "version_tag=${VERSION_TAG}" >> "$GITHUB_OUTPUT"
+          echo "Resolved: ${VERSION_TAG} (torch ${TORCH_VER}+rocm${ROCM_VER}, vLLM ${VLLM_REF})"
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Check if combo already built
+        id: check
+        run: |
+          set -uo pipefail
+          REF="docker.io/${{ steps.repo.outputs.repo }}:${{ steps.ver.outputs.version_tag }}"
+          if [ "${{ github.event.inputs.force }}" = "true" ]; then
+            echo "force=true -> rebuilding regardless"; echo "skip=false" >> "$GITHUB_OUTPUT"
+          elif docker buildx imagetools inspect "$REF" >/dev/null 2>&1; then
+            echo "✅ $REF already exists — skipping"; echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "🆕 $REF not found — building"; echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Put Docker on /mnt
+        if: steps.check.outputs.skip != 'true'
+        run: |
+          set -eux
+          echo '{ "data-root": "/mnt/docker" }' | sudo tee /etc/docker/daemon.json
+          sudo systemctl stop docker
+          sudo rm -rf /var/lib/docker || true
+          sudo mkdir -p /mnt/docker
+          sudo systemctl start docker
+          docker info | grep "Docker Root Dir"
+          echo "${{ secrets.DOCKERHUB_TOKEN }}" | docker login -u "${{ secrets.DOCKERHUB_USERNAME }}" --password-stdin
+
+      - name: Free disk space
+        if: steps.check.outputs.skip != 'true'
+        shell: bash
+        run: |
+          set -euxo pipefail
+          echo "Disk BEFORE:"; df -h
+          sudo rm -rf /usr/local/lib/android /usr/share/dotnet /opt/ghc || true
+          sudo rm -rf /opt/hostedtoolcache || true
+          docker system prune -af || true
+          docker builder prune -af || true
+          sudo apt-get clean; sudo rm -rf /var/lib/apt/lists/*
+          echo "Disk AFTER:"; df -h
+
+      - name: Set up QEMU
+        if: steps.check.outputs.skip != 'true'
+        uses: docker/setup-qemu-action@v3
+
+      - name: BuildKit GC config (8GB cap)
+        if: steps.check.outputs.skip != 'true'
+        run: |
+          cat > /tmp/buildkitd.toml <<'EOF'
+          [worker.oci]
+            gc = true
+            gckeepstorage = 8000
+          EOF
+
+      - name: Set up Buildx (with GC)
+        if: steps.check.outputs.skip != 'true'
+        uses: docker/setup-buildx-action@v3
+        with:
+          buildkitd-flags: --config /tmp/buildkitd.toml
+
+      - name: Docker meta
+        if: steps.check.outputs.skip != 'true'
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: docker.io/${{ steps.repo.outputs.repo }}
+          tags: |
+            type=raw,value=${{ steps.ver.outputs.version_tag }}
+            type=raw,value=latest
+            type=raw,value={{date 'YYYYMMDD-HHmmss'}}
+          labels: |
+            org.opencontainers.image.source=https://github.com/${{ github.repository }}
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.version=${{ steps.ver.outputs.version_tag }}
+
+      - name: Build & push image
+        if: steps.check.outputs.skip != 'true'
+        id: build
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile.ubuntu-repoamd
+          platforms: linux/amd64
+          push: true
+          pull: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            ROCM_WHL=${{ env.ROCM_WHL }}
+            TORCH_VERSION=${{ steps.ver.outputs.torch_ver }}
+            ROCM_VERSION=${{ steps.ver.outputs.rocm_ver }}
+            VLLM_REF=${{ steps.ver.outputs.vllm_ref }}
+          provenance: false
+          sbom: false
+          # Fresh cache ref (buildcache-repoamd): the old :buildcache was contaminated by the
+          # retired dev-ubuntu/nightly builds and reused a stale unpatched rocm.py layer,
+          # shipping broken vision. This ref only ever sees Dockerfile.ubuntu-repoamd layers.
+          cache-from: type=registry,ref=docker.io/${{ steps.repo.outputs.repo }}:buildcache-repoamd
+          cache-to: type=registry,ref=docker.io/${{ steps.repo.outputs.repo }}:buildcache-repoamd,mode=max,image-manifest=true,oci-mediatypes=true
+
+      - name: Prune buildx cache
+        if: always()
+        run: docker buildx prune -af --verbose --min-free-space 4gb || true

--- a/.github/workflows/build-ubuntu-stable.yml
+++ b/.github/workflows/build-ubuntu-stable.yml
@@ -4,15 +4,15 @@ name: build-ubuntu-stable
 # Publishes docker.io/<owner>/vllm-rocm-gfx1151. Replaces the two former Ubuntu images
 # (old dev-ubuntu base + the nightly variant) — see Dockerfile.ubuntu-repoamd.
 #
-# Off the nightly treadmill: the whole gfx1151 ROCm/torch stack is STABLE per-arch wheels
-# from https://repo.amd.com/rocm/whl/gfx1151/ (torch X.Y.Z+rocmA.B.C, release — not alpha).
-# torch brings its own matched ROCm -> no system-vs-pip ABI mismatch. Vision works via a
-# ROCm flash-attention + aiter build (ViT Flash Attention, not the SDPA path that OOMs).
-# First serve of a model autotunes the Triton GDN+ViT kernels on the GPU (a few min); mount a
-# persistent host dir at TRITON_CACHE_DIR (/opt/triton_cache) to keep that cache across runs.
+# Off the nightly treadmill: STABLE release wheels from https://repo.amd.com/rocm/whl-multi-arch/
+# (TheRock multi-arch device-package layout, ROCm 7.14). torch brings its own matched ROCm ->
+# no system-vs-pip ABI mismatch. Vision works via a ROCm flash-attention + aiter build (ViT
+# Flash Attention, not the SDPA path that OOMs). First serve autotunes the Triton GDN+ViT
+# kernels on the GPU (a few min); mount a host dir at TRITON_CACHE_DIR to persist that cache.
 #
-# DAILY cron auto-resolves the newest stable gfx1151 torch + latest vLLM stable tag and
-# rebuilds only when the resolved combo changed (immutable tag -> registry hit = no-op).
+# The torch stack is PINNED (torch+rocm here; torchvision/torchaudio/device derived in the
+# Dockerfile) — bump deliberately after a GPU verify. Only vLLM (latest stable tag) is
+# auto-resolved. DAILY cron rebuilds only when the combo changed (immutable tag -> no-op).
 
 on:
   schedule:
@@ -58,10 +58,10 @@ jobs:
           # match the vLLM we build — so we bump this deliberately after a GPU verify rather than
           # auto-resolving newest (which risks an unverified/incompatible combo). Confirm the
           # pinned combo still exists on the index (fail loudly if AMD moves/removes it).
+          # torchvision/torchaudio are DERIVED from TORCH_VER inside the Dockerfile (torchaudio
+          # == torch; torchvision == 0.(minor+15)); only torch+rocm are pinned here.
           TORCH_VER=2.11.0
           ROCM_VER=7.14.0
-          TORCHVISION_VER=0.26.0
-          TORCHAUDIO_VER=2.11.0
           curl -fsSL "${ROCM_WHL}amd-torch-device-gfx1151/" \
             | grep -q "amd_torch_device_gfx1151-${TORCH_VER}+rocm${ROCM_VER}-cp312-cp312-linux" \
             || { echo "pinned torch device pkg ${TORCH_VER}+rocm${ROCM_VER} not found on ${ROCM_WHL}" >&2; exit 1; }
@@ -81,8 +81,6 @@ jobs:
           VERSION_TAG="rocm${ROCM_VER}-torch${TORCH_VER}-vllm${VLLM_SLUG}"
           echo "torch_ver=${TORCH_VER}"     >> "$GITHUB_OUTPUT"
           echo "rocm_ver=${ROCM_VER}"       >> "$GITHUB_OUTPUT"
-          echo "torchvision_ver=${TORCHVISION_VER}" >> "$GITHUB_OUTPUT"
-          echo "torchaudio_ver=${TORCHAUDIO_VER}"   >> "$GITHUB_OUTPUT"
           echo "vllm_ref=${VLLM_REF}"       >> "$GITHUB_OUTPUT"
           echo "version_tag=${VERSION_TAG}" >> "$GITHUB_OUTPUT"
           echo "Resolved: ${VERSION_TAG} (torch ${TORCH_VER}+rocm${ROCM_VER}, vLLM ${VLLM_REF})"
@@ -181,8 +179,6 @@ jobs:
             ROCM_WHL=${{ env.ROCM_WHL }}
             TORCH_VERSION=${{ steps.ver.outputs.torch_ver }}
             ROCM_VERSION=${{ steps.ver.outputs.rocm_ver }}
-            TORCHVISION_VERSION=${{ steps.ver.outputs.torchvision_ver }}
-            TORCHAUDIO_VERSION=${{ steps.ver.outputs.torchaudio_ver }}
             VLLM_REF=${{ steps.ver.outputs.vllm_ref }}
           provenance: false
           sbom: false

--- a/.github/workflows/build-ubuntu-stable.yml
+++ b/.github/workflows/build-ubuntu-stable.yml
@@ -31,7 +31,7 @@ on:
 
 env:
   DOCKER_BUILDKIT: "1"
-  ROCM_WHL: https://repo.amd.com/rocm/whl/gfx1151/
+  ROCM_WHL: https://repo.amd.com/rocm/whl-multi-arch/
 
 jobs:
   build:
@@ -53,13 +53,18 @@ jobs:
         id: ver
         run: |
           set -euo pipefail
-          # Newest STABLE gfx1151 torch on repo.amd.com (release build, e.g. 2.11.0+rocm7.13.0).
-          LATEST=$(curl -fsSL "${ROCM_WHL}torch/" \
-            | grep -oE 'torch-[0-9][0-9.]*\+rocm[0-9.]+-cp312-cp312-linux' \
-            | sed -E 's/^torch-//; s/-cp312-cp312-linux$//' \
-            | sort -V | tail -n1)
-          TORCH_VER="${LATEST%%+*}"        # 2.11.0
-          ROCM_VER="${LATEST##*+rocm}"     # 7.13.0
+          # Torch stack PINNED to a verified, mutually-compatible combo on the multi-arch index.
+          # torch<->torchvision<->torchaudio<->gfx1151 device pkg are coupled, and torch must
+          # match the vLLM we build — so we bump this deliberately after a GPU verify rather than
+          # auto-resolving newest (which risks an unverified/incompatible combo). Confirm the
+          # pinned combo still exists on the index (fail loudly if AMD moves/removes it).
+          TORCH_VER=2.11.0
+          ROCM_VER=7.14.0
+          TORCHVISION_VER=0.26.0
+          TORCHAUDIO_VER=2.11.0
+          curl -fsSL "${ROCM_WHL}amd-torch-device-gfx1151/" \
+            | grep -q "amd_torch_device_gfx1151-${TORCH_VER}+rocm${ROCM_VER}-cp312-cp312-linux" \
+            || { echo "pinned torch device pkg ${TORCH_VER}+rocm${ROCM_VER} not found on ${ROCM_WHL}" >&2; exit 1; }
           # vLLM: manual override, else latest stable release tag (skip rc/dev/a/b).
           VLLM_REF="${{ github.event.inputs.vllm_ref }}"
           if [ -z "$VLLM_REF" ]; then
@@ -76,6 +81,8 @@ jobs:
           VERSION_TAG="rocm${ROCM_VER}-torch${TORCH_VER}-vllm${VLLM_SLUG}"
           echo "torch_ver=${TORCH_VER}"     >> "$GITHUB_OUTPUT"
           echo "rocm_ver=${ROCM_VER}"       >> "$GITHUB_OUTPUT"
+          echo "torchvision_ver=${TORCHVISION_VER}" >> "$GITHUB_OUTPUT"
+          echo "torchaudio_ver=${TORCHAUDIO_VER}"   >> "$GITHUB_OUTPUT"
           echo "vllm_ref=${VLLM_REF}"       >> "$GITHUB_OUTPUT"
           echo "version_tag=${VERSION_TAG}" >> "$GITHUB_OUTPUT"
           echo "Resolved: ${VERSION_TAG} (torch ${TORCH_VER}+rocm${ROCM_VER}, vLLM ${VLLM_REF})"
@@ -174,6 +181,8 @@ jobs:
             ROCM_WHL=${{ env.ROCM_WHL }}
             TORCH_VERSION=${{ steps.ver.outputs.torch_ver }}
             ROCM_VERSION=${{ steps.ver.outputs.rocm_ver }}
+            TORCHVISION_VERSION=${{ steps.ver.outputs.torchvision_ver }}
+            TORCHAUDIO_VERSION=${{ steps.ver.outputs.torchaudio_ver }}
             VLLM_REF=${{ steps.ver.outputs.vllm_ref }}
           provenance: false
           sbom: false

--- a/.github/workflows/build-ubuntu-stable.yml
+++ b/.github/workflows/build-ubuntu-stable.yml
@@ -10,9 +10,10 @@ name: build-ubuntu-stable
 # Flash Attention, not the SDPA path that OOMs). First serve autotunes the Triton GDN+ViT
 # kernels on the GPU (a few min); mount a host dir at TRITON_CACHE_DIR to persist that cache.
 #
-# The torch stack is PINNED (torch+rocm here; torchvision/torchaudio/device derived in the
-# Dockerfile) — bump deliberately after a GPU verify. Only vLLM (latest stable tag) is
-# auto-resolved. DAILY cron rebuilds only when the combo changed (immutable tag -> no-op).
+# Fully AUTO-DISCOVERED — no manual pins: the resolve step finds the newest torch on the index
+# that has a COMPLETE aligned gfx1151 set (torch + device + torchvision + torchaudio, same rocm),
+# and torchvision/torchaudio/device are derived from that torch in the Dockerfile. vLLM = latest
+# stable tag. DAILY cron rebuilds only when the resolved combo changed (immutable tag -> no-op).
 
 on:
   schedule:
@@ -53,18 +54,30 @@ jobs:
         id: ver
         run: |
           set -euo pipefail
-          # Torch stack PINNED to a verified, mutually-compatible combo on the multi-arch index.
-          # torch<->torchvision<->torchaudio<->gfx1151 device pkg are coupled, and torch must
-          # match the vLLM we build — so we bump this deliberately after a GPU verify rather than
-          # auto-resolving newest (which risks an unverified/incompatible combo). Confirm the
-          # pinned combo still exists on the index (fail loudly if AMD moves/removes it).
-          # torchvision/torchaudio are DERIVED from TORCH_VER inside the Dockerfile (torchaudio
-          # == torch; torchvision == 0.(minor+15)); only torch+rocm are pinned here.
-          TORCH_VER=2.11.0
-          ROCM_VER=7.14.0
-          curl -fsSL "${ROCM_WHL}amd-torch-device-gfx1151/" \
-            | grep -q "amd_torch_device_gfx1151-${TORCH_VER}+rocm${ROCM_VER}-cp312-cp312-linux" \
-            || { echo "pinned torch device pkg ${TORCH_VER}+rocm${ROCM_VER} not found on ${ROCM_WHL}" >&2; exit 1; }
+          # AUTO-DISCOVER the newest gfx1151 torch stack on the multi-arch index — no manual pins.
+          # The 4 torch packages are coupled and publish at slightly different times (e.g. torch
+          # 2.12 can exist before torchaudio 2.12), so we iterate torch versions newest-first and
+          # pick the first with a COMPLETE aligned set present for the same rocm:
+          #   torch + amd-torch-device-gfx1151 + torchvision(0.[minor+15]) + torchaudio.
+          # torchvision/torchaudio/device are then derived from TORCH_VER in the Dockerfile.
+          DEV_LIST=$(curl -fsSL "${ROCM_WHL}amd-torch-device-gfx1151/")
+          TORCH_LIST=$(curl -fsSL "${ROCM_WHL}torch/")
+          TV_LIST=$(curl -fsSL "${ROCM_WHL}torchvision/")
+          TA_LIST=$(curl -fsSL "${ROCM_WHL}torchaudio/")
+          CANDS=$(printf '%s' "$DEV_LIST" \
+            | grep -oE 'amd_torch_device_gfx1151-[0-9][0-9.]*\+rocm[0-9.]+-cp312-cp312-linux' \
+            | sed -E 's/^amd_torch_device_gfx1151-//; s/-cp312-cp312-linux$//' | sort -Vr | uniq)
+          TORCH_VER=""; ROCM_VER=""
+          for c in $CANDS; do
+            t="${c%%+*}"; r="${c##*+rocm}"
+            tvm=$(( $(echo "$t" | cut -d. -f2) + 15 )); tv="0.${tvm}.0"
+            printf '%s' "$TORCH_LIST" | grep -q "torch-${t}+rocm${r}-cp312-cp312-linux"            || continue
+            printf '%s' "$TV_LIST"    | grep -q "torchvision-${tv}+rocm${r}-cp312-cp312-linux"     || continue
+            printf '%s' "$TA_LIST"    | grep -q "torchaudio-${t}+rocm${r}-cp312-cp312-linux"       || continue
+            TORCH_VER="$t"; ROCM_VER="$r"; break
+          done
+          [ -n "$TORCH_VER" ] || { echo "no complete gfx1151 torch stack found on ${ROCM_WHL}" >&2; exit 1; }
+          echo "Auto-discovered aligned stack: torch ${TORCH_VER}+rocm${ROCM_VER} (torchvision 0.$(( $(echo "$TORCH_VER"|cut -d. -f2)+15 )).0, torchaudio ${TORCH_VER})"
           # vLLM: manual override, else latest stable release tag (skip rc/dev/a/b).
           VLLM_REF="${{ github.event.inputs.vllm_ref }}"
           if [ -z "$VLLM_REF" ]; then

--- a/Dockerfile
+++ b/Dockerfile
@@ -194,5 +194,10 @@ RUN chmod +x /opt/start-vllm /opt/start-vllm-cluster /opt/vllm_cluster_bench.py 
 RUN chmod 0644 /etc/profile.d/*.sh
 RUN printf 'ulimit -S -c 0\n' > /etc/profile.d/90-nocoredump.sh && chmod 0644 /etc/profile.d/90-nocoredump.sh
 
+# rdma group: podman resolves `--group-add rdma` against the CONTAINER's /etc/group and ABORTS
+# the start if the name is missing. Fedora ships video(39) + render(105) but no rdma, so
+# refresh_toolbox.sh's InfiniBand branch (`--group-add rdma`, added whenever /dev/infiniband
+# exists) could not start this image on any RDMA host. -f keeps it idempotent.
+RUN groupadd -f -g 101 rdma
 
 CMD ["/bin/bash"]

--- a/Dockerfile.ubuntu-repoamd
+++ b/Dockerfile.ubuntu-repoamd
@@ -1,0 +1,178 @@
+# syntax=docker/dockerfile:1
+# Ubuntu 24.04 + STABLE ROCm/torch for gfx1151 (Strix Halo), pip-first (TheRock era).
+# Multi-stage, slim (~9 GB), with WORKING VISION.
+#
+# Off the nightly treadmill: the whole gfx1151 ROCm/torch stack is STABLE per-arch wheels
+# from https://repo.amd.com/rocm/whl/gfx1151/ (torch 2.x+rocmX.Y.0 — release, not alpha).
+# torch brings its own matched ROCm (_rocm_sdk_core) → no system-vs-pip ABI mismatch
+# (that mix segfaulted the old dev-ubuntu:7.14 + nightly-torch attempt).
+#
+# Vision: gfx1151 vLLM would fall back to Torch SDPA for the ViT encoder (OOMs at 256 GiB),
+# so we build ROCm flash-attention + aiter Triton kernels and enable them
+# (FLASH_ATTENTION_TRITON_AMD_ENABLE + PR #40289 detection patch). aiter's C++ JIT module is
+# pre-warmed at build so the dev SDK can be dropped while vision still works at runtime.
+#
+# BASE = 24.04 / py3.12: 26.04 ships py3.14 but vLLM's amd-quark dep has no py3.14 wheel yet.
+
+# ============================ Stage 1: builder ============================
+FROM docker.io/ubuntu:24.04 AS builder
+ENV DEBIAN_FRONTEND=noninteractive FLASH_ATTENTION_TRITON_AMD_ENABLE=TRUE
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      python3.12-venv python3.12-dev python3-pip \
+      git aria2 ffmpeg vim nano rsync curl ca-certificates xz-utils patch pkg-config \
+      protobuf-compiler libgoogle-perftools-dev libnuma-dev numactl libdrm-dev \
+      libibverbs-dev ibverbs-utils rdma-core rustc cargo build-essential \
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
+
+RUN python3.12 -m venv /opt/venv
+ENV VIRTUAL_ENV=/opt/venv PATH=/opt/venv/bin:$PATH PIP_NO_CACHE_DIR=1 PYTHONNOUSERSITE=1
+RUN python -m pip install --upgrade pip wheel packaging "setuptools<80.0.0" "setuptools-rust>=1.9.0"
+
+# STABLE gfx1151 stack from repo.amd.com; rocm[devel] adds hipcc/headers/cmake to build.
+ARG ROCM_WHL=https://repo.amd.com/rocm/whl/gfx1151/
+ARG TORCH_VERSION=2.11.0
+ARG ROCM_VERSION=7.13.0
+RUN python -m pip install --index-url ${ROCM_WHL} --extra-index-url https://pypi.org/simple \
+      "torch==${TORCH_VERSION}" "rocm[devel]==${ROCM_VERSION}" torchaudio torchvision
+RUN python -m pip install --upgrade cmake ninja numpy "setuptools-scm>=8" \
+      "setuptools<80.0.0" scikit-build-core pybind11 numba scipy einops
+
+# amdsmi ships in the rocm-sdk but isn't importable — install + patch APU VRAM-carveout bug.
+RUN ROOT=$(rocm-sdk path --root) && python -m pip install "${ROOT}/share/amd_smi"
+COPY scripts/patch_amdsmi.py /opt/patch_amdsmi.py
+RUN python /opt/patch_amdsmi.py
+
+# --- VISION: ROCm flash-attention + aiter + composable_kernel (Triton ViT kernels) ---
+# Built against the pip rocm-sdk for gfx1151 so the ViT uses Flash Attention, not SDPA.
+COPY scripts/patch_aiter_headers.py /opt/patch_aiter_headers.py
+RUN set -e; ROOT=$(rocm-sdk path --root); \
+    export ROCM_PATH=$ROOT HIP_PATH=$ROOT \
+      PATH=$ROOT/bin:$ROOT/lib/llvm/bin:$PATH \
+      CC=$ROOT/lib/llvm/bin/amdclang CXX=$ROOT/lib/llvm/bin/amdclang++ \
+      HIP_DEVICE_LIB_PATH=$ROOT/lib/llvm/amdgcn/bitcode \
+      CMAKE_PREFIX_PATH=$ROOT/lib/cmake:$ROOT \
+      LD_LIBRARY_PATH=$ROOT/lib:$ROOT/lib/llvm/lib \
+      PYTORCH_ROCM_ARCH=gfx1151 GPU_ARCHS=gfx1151 AMDGPU_TARGETS=gfx1151; \
+    cd /opt && git clone https://github.com/ROCm/flash-attention.git && \
+    cd flash-attention && git checkout main_perf && \
+    git submodule update --init third_party/aiter && \
+    cd third_party/aiter && git submodule update --init 3rdparty/composable_kernel && \
+    export CK_DIR="$(pwd)/3rdparty/composable_kernel" && \
+    python -m pip wheel --no-build-isolation --no-deps -w /tmp/aiter_dist -v . && \
+    python -m pip install --force-reinstall /tmp/aiter_dist/amd_aiter*.whl && \
+    python /opt/patch_aiter_headers.py && \
+    cd /opt/flash-attention && \
+    python -c "import re; f=open('setup.py'); t=f.read(); f.close(); t=re.sub(r'subprocess\.run\([\s\S]*?third_party/aiter[\s\S]*?check=True,\s*\)', 'pass # patched', t); open('setup.py','w').write(t)" && \
+    pip install --no-build-isolation --no-deps . && \
+    cd /opt && rm -rf /opt/flash-attention /tmp/aiter_dist
+
+# Build vLLM from source against the pip rocm-sdk (matched to torch → no ABI mix).
+ARG VLLM_REF=eb28452b1
+ARG MAX_JOBS=4
+ENV MAX_JOBS=${MAX_JOBS} PYTORCH_ROCM_ARCH=gfx1151 VLLM_TARGET_DEVICE=rocm \
+    ROCBLAS_USE_HIPBLASLT=1 HIP_FORCE_DEV_KERNARG=1 VLLM_USE_TRITON_AWQ=1 MIOPEN_FIND_MODE=FAST
+WORKDIR /opt
+RUN git clone https://github.com/vllm-project/vllm.git /opt/vllm && \
+    cd /opt/vllm && if [ -n "$VLLM_REF" ]; then git checkout "$VLLM_REF"; fi
+WORKDIR /opt/vllm
+COPY scripts/patch_strix.py /opt/vllm/patch_strix.py
+RUN python /opt/vllm/patch_strix.py
+RUN ROOT=$(rocm-sdk path --root) && \
+    export ROCM_PATH=$ROOT HIP_PATH=$ROOT \
+      PATH=$ROOT/bin:$ROOT/lib/llvm/bin:$PATH \
+      CC=$ROOT/lib/llvm/bin/amdclang CXX=$ROOT/lib/llvm/bin/amdclang++ \
+      HIP_DEVICE_LIB_PATH=$ROOT/lib/llvm/amdgcn/bitcode \
+      CMAKE_PREFIX_PATH=$ROOT/lib/cmake:$ROOT \
+      LD_LIBRARY_PATH=$ROOT/lib:$ROOT/lib/llvm/lib && \
+    export CMAKE_ARGS="-DROCM_PATH=$ROOT -DHIP_PATH=$ROOT -DAMDGPU_TARGETS=gfx1151 -DHIP_ARCHITECTURES=gfx1151" && \
+    python -m pip wheel --no-build-isolation --no-deps -w /tmp/dist -v . && \
+    python -m pip install /tmp/dist/*.whl && rm -rf /tmp/dist
+RUN python -m pip install ray
+
+# #40289 (required): this flash-attn build ships the Triton-AMD kernels at the aiter
+# location, so make flash_attn_triton_available() detect them there (else ViT -> SDPA OOM).
+# Target the INSTALLED venv copy via sysconfig purelib — NOT find_spec("vllm"), which at this
+# WORKDIR (/opt/vllm) resolves to the source tree that gets rm -rf'd, leaving the shipped
+# copy unpatched (cost us a broken CI image).
+RUN python - <<'PY'
+import os, sysconfig
+p = os.path.join(sysconfig.get_paths()["purelib"], "vllm", "platforms", "rocm.py")
+assert os.path.exists(p), f"installed vllm rocm.py not found at {p}"
+s = open(p).read()
+old = '''        if find_spec("flash_attn") is None:
+            return False
+        if find_spec("flash_attn.flash_attn_triton_amd") is None:
+            return False'''
+new = '''        def _has(n):
+            try:
+                return find_spec(n) is not None
+            except (ImportError, ValueError):
+                return False
+        if not (_has("flash_attn.flash_attn_triton_amd")
+                or _has("aiter.ops.triton._triton_kernels.flash_attn_triton_amd")):
+            return False'''
+if old in s:
+    open(p,"w").write(s.replace(old,new,1)); print("patched rocm.py ViT detection (#40289)")
+elif "aiter.ops.triton._triton_kernels.flash_attn_triton_amd" in s:
+    print("rocm.py already detects the aiter location; no patch needed")
+else:
+    raise SystemExit("ERROR: rocm.py flash_attn_triton_available anchor not found")
+PY
+
+# --- SLIM: pre-warm aiter's C++ JIT (module_aiter_enum) while hipcc is present, then drop
+#     the 12 GB dev SDK. Vision still works at runtime (JIT cached; git in runtime image).
+#     amdsmi resolves libamd_smi.so via _rocm_sdk_core (unversioned symlink + runtime ROCM_PATH).
+RUN ROOT=$(rocm-sdk path --root) && \
+    export ROCM_PATH=$ROOT HIP_PATH=$ROOT \
+      PATH=$ROOT/bin:$ROOT/lib/llvm/bin:$PATH \
+      HIP_DEVICE_LIB_PATH=$ROOT/lib/llvm/amdgcn/bitcode \
+      LD_LIBRARY_PATH=$ROOT/lib:$ROOT/lib/llvm/lib && \
+    python -c "import aiter; print('aiter JIT prewarmed OK')"
+RUN CORE=/opt/venv/lib/python3.12/site-packages/_rocm_sdk_core && \
+    python -m pip uninstall -y rocm-sdk-devel && \
+    ln -sf libamd_smi.so.26 "$CORE/lib/libamd_smi.so" && \
+    rm -rf /opt/vllm /root/.cache/pip && \
+    find /opt/venv -name '*.a' -delete 2>/dev/null || true
+
+# ============================ Stage 2: runtime (slim) ============================
+FROM docker.io/ubuntu:24.04 AS runtime
+ENV DEBIAN_FRONTEND=noninteractive
+
+# gcc + python3.12-dev: Triton JIT-compiles a host driver module on first kernel use.
+# git: aiter/flash_attn call git for version detection at import.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      python3.12 python3.12-dev gcc git ca-certificates curl \
+      libatomic1 libnuma1 libgomp1 libelf1 libdrm2 libdrm-amdgpu1 libtinfo6 zlib1g libssl3 \
+      libgoogle-perftools4 libibverbs1 librdmacm1 \
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
+
+COPY --from=builder /opt/venv /opt/venv
+
+# Fail-fast: the ViT flash-attn detection MUST reference the aiter kernel location (#40289),
+# else vision silently falls back to Torch SDPA and OOMs. Guards against a stale buildcache
+# layer shipping an unpatched rocm.py (this cost us a broken CI image once).
+RUN grep -q "aiter.ops.triton._triton_kernels.flash_attn_triton_amd" \
+      /opt/venv/lib/python3.12/site-packages/vllm/platforms/rocm.py \
+    || { echo "ERROR: rocm.py ViT flash-attn detection is NOT patched for aiter (#40289)"; exit 1; }
+
+# Triton kernel cache lives here (TRITON_CACHE_DIR below). On FIRST serve of a model, Triton
+# autotunes the GDN + ViT flash-attn kernels on the live GPU (a few minutes) and writes them
+# here; subsequent starts reuse them. We deliberately do NOT bake a pre-warmed cache into the
+# image: it is keyed to the exact torch/triton/vLLM it was warmed with, so under auto-resolve
+# it would go stale and silently miss. Instead, mount a persistent host dir here to keep the
+# cache across container restarts and image bumps, e.g.:
+#     -v "$HOME/.cache/triton-gfx1151:/opt/triton_cache"
+RUN mkdir -p /opt/triton_cache
+
+# ROCM_PATH/LD_LIBRARY_PATH → pip rocm-sdk (core + gfx1151 libraries); amdsmi resolves
+# libamd_smi.so via $ROCM_PATH/lib (builder added the unversioned symlink in core).
+# FLASH_ATTENTION_TRITON_AMD_ENABLE enables the ViT flash-attn path. Paths deterministic.
+ENV VIRTUAL_ENV=/opt/venv PATH=/opt/venv/bin:$PATH PYTHONNOUSERSITE=1 \
+    ROCM_PATH=/opt/venv/lib/python3.12/site-packages/_rocm_sdk_core \
+    LD_LIBRARY_PATH=/opt/venv/lib/python3.12/site-packages/_rocm_sdk_core/lib:/opt/venv/lib/python3.12/site-packages/_rocm_sdk_libraries_gfx1151/lib \
+    PYTORCH_ROCM_ARCH=gfx1151 ROCBLAS_USE_HIPBLASLT=1 FLASH_ATTENTION_TRITON_AMD_ENABLE=TRUE \
+    HIP_FORCE_DEV_KERNARG=1 VLLM_USE_TRITON_AWQ=1 MIOPEN_FIND_MODE=FAST \
+    TRITON_CACHE_DIR=/opt/triton_cache
+WORKDIR /opt
+CMD ["/bin/bash"]

--- a/Dockerfile.ubuntu-repoamd
+++ b/Dockerfile.ubuntu-repoamd
@@ -159,11 +159,28 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 # gcc + python3.12-dev: Triton JIT-compiles a host driver module on first kernel use.
 # git: aiter/flash_attn call git for version detection at import.
+# sudo: toolbx/distrobox run their in-container user setup through it.
 RUN apt-get update && apt-get install -y --no-install-recommends \
-      python3.12 python3.12-dev gcc git ca-certificates curl \
+      python3.12 python3.12-dev gcc git ca-certificates curl sudo \
       libatomic1 libnuma1 libgomp1 libelf1 libdrm2 libdrm-amdgpu1 libtinfo6 zlib1g libssl3 \
       libgoogle-perftools4 libibverbs1 librdmacm1 \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
+
+# Container-workflow compatibility (toolbx / distrobox / plain `podman run --group-add ...`).
+#  * render group: podman resolves `--group-add render` against the CONTAINER's /etc/group and
+#    ABORTS the start if the name is missing ("unable to find group render: no matching entries
+#    in group file"). Ubuntu ships video(44) and rdma(101) but no render, so every documented
+#    toolbox/distrobox/podman command in the README failed to start at all on this image.
+#    gid 105 matches the Fedora image for parity; -f keeps it idempotent (and transparently
+#    picks a free gid if 105 is ever taken).
+#    NOTE: under ROOTLESS podman these container gids never map to host gids, so --group-add
+#    video/render alone does NOT grant /dev/kfd access — `--group-add keep-groups` is what
+#    does (toolbx/distrobox inject it automatically). This only removes the hard failure.
+#  * libdrm_amdgpu.so: amdsmi dlopen()s the UNVERSIONED soname, which ships only in libdrm-dev.
+#    Without the symlink `rocm-smi` (the README's own verification step) prints "get_name,
+#    Failed to load a library" and no GPU name, even though the GPU is perfectly usable.
+RUN groupadd -f -g 105 render \
+ && ln -sf libdrm_amdgpu.so.1 /usr/lib/x86_64-linux-gnu/libdrm_amdgpu.so
 
 COPY --from=builder /opt/venv /opt/venv
 

--- a/Dockerfile.ubuntu-repoamd
+++ b/Dockerfile.ubuntu-repoamd
@@ -2,9 +2,9 @@
 # Ubuntu 24.04 + STABLE ROCm/torch for gfx1151 (Strix Halo), pip-first (TheRock era).
 # Multi-stage, slim (~9 GB), with WORKING VISION.
 #
-# Off the nightly treadmill: the whole gfx1151 ROCm/torch stack is STABLE per-arch wheels
-# from https://repo.amd.com/rocm/whl/gfx1151/ (torch 2.x+rocmX.Y.0 — release, not alpha).
-# torch brings its own matched ROCm (_rocm_sdk_core) → no system-vs-pip ABI mismatch
+# Off the nightly treadmill: the whole gfx1151 ROCm/torch stack is STABLE release wheels from
+# https://repo.amd.com/rocm/whl-multi-arch/ (TheRock multi-arch device-package layout; ROCm
+# 7.14). torch brings its own matched ROCm (_rocm_sdk_core) → no system-vs-pip ABI mismatch
 # (that mix segfaulted the old dev-ubuntu:7.14 + nightly-torch attempt).
 #
 # Vision: gfx1151 vLLM would fall back to Torch SDPA for the ViT encoder (OOMs at 256 GiB),
@@ -29,12 +29,23 @@ RUN python3.12 -m venv /opt/venv
 ENV VIRTUAL_ENV=/opt/venv PATH=/opt/venv/bin:$PATH PIP_NO_CACHE_DIR=1 PYTHONNOUSERSITE=1
 RUN python -m pip install --upgrade pip wheel packaging "setuptools<80.0.0" "setuptools-rust>=1.9.0"
 
-# STABLE gfx1151 stack from repo.amd.com; rocm[devel] adds hipcc/headers/cmake to build.
-ARG ROCM_WHL=https://repo.amd.com/rocm/whl/gfx1151/
+# STABLE gfx1151 stack from repo.amd.com — TheRock multi-arch "device package" layout:
+# a GENERIC base (torch, rocm-sdk-core/-libraries/-devel) + a thin PER-ARCH device package
+# (amd-torch-device-gfx1151, rocm-sdk-device-gfx1151) that overlays the gfx1151 kernels.
+# ROCm 7.14 lives here; the legacy per-arch whl/gfx1151/ index is frozen at 7.13.0.
+# Torch stack is PINNED to a verified, mutually-compatible combo (the 4 packages are coupled,
+# and torch must match the vLLM we build) — bump deliberately. rocm-sdk-devel = build SDK.
+ARG ROCM_WHL=https://repo.amd.com/rocm/whl-multi-arch/
 ARG TORCH_VERSION=2.11.0
-ARG ROCM_VERSION=7.13.0
+ARG ROCM_VERSION=7.14.0
+ARG TORCHVISION_VERSION=0.26.0
+ARG TORCHAUDIO_VERSION=2.11.0
 RUN python -m pip install --index-url ${ROCM_WHL} --extra-index-url https://pypi.org/simple \
-      "torch==${TORCH_VERSION}" "rocm[devel]==${ROCM_VERSION}" torchaudio torchvision
+      "torch==${TORCH_VERSION}+rocm${ROCM_VERSION}" \
+      "amd-torch-device-gfx1151==${TORCH_VERSION}+rocm${ROCM_VERSION}" \
+      "rocm-sdk-devel==${ROCM_VERSION}" "rocm-sdk-device-gfx1151==${ROCM_VERSION}" \
+      "torchvision==${TORCHVISION_VERSION}+rocm${ROCM_VERSION}" \
+      "torchaudio==${TORCHAUDIO_VERSION}+rocm${ROCM_VERSION}"
 RUN python -m pip install --upgrade cmake ninja numpy "setuptools-scm>=8" \
       "setuptools<80.0.0" scikit-build-core pybind11 numba scipy einops
 
@@ -170,7 +181,7 @@ RUN mkdir -p /opt/triton_cache
 # FLASH_ATTENTION_TRITON_AMD_ENABLE enables the ViT flash-attn path. Paths deterministic.
 ENV VIRTUAL_ENV=/opt/venv PATH=/opt/venv/bin:$PATH PYTHONNOUSERSITE=1 \
     ROCM_PATH=/opt/venv/lib/python3.12/site-packages/_rocm_sdk_core \
-    LD_LIBRARY_PATH=/opt/venv/lib/python3.12/site-packages/_rocm_sdk_core/lib:/opt/venv/lib/python3.12/site-packages/_rocm_sdk_libraries_gfx1151/lib \
+    LD_LIBRARY_PATH=/opt/venv/lib/python3.12/site-packages/_rocm_sdk_core/lib:/opt/venv/lib/python3.12/site-packages/_rocm_sdk_libraries/lib \
     PYTORCH_ROCM_ARCH=gfx1151 ROCBLAS_USE_HIPBLASLT=1 FLASH_ATTENTION_TRITON_AMD_ENABLE=TRUE \
     HIP_FORCE_DEV_KERNARG=1 VLLM_USE_TRITON_AWQ=1 MIOPEN_FIND_MODE=FAST \
     TRITON_CACHE_DIR=/opt/triton_cache

--- a/Dockerfile.ubuntu-repoamd
+++ b/Dockerfile.ubuntu-repoamd
@@ -35,17 +35,24 @@ RUN python -m pip install --upgrade pip wheel packaging "setuptools<80.0.0" "set
 # ROCm 7.14 lives here; the legacy per-arch whl/gfx1151/ index is frozen at 7.13.0.
 # Torch stack is PINNED to a verified, mutually-compatible combo (the 4 packages are coupled,
 # and torch must match the vLLM we build) — bump deliberately. rocm-sdk-devel = build SDK.
+# SINGLE SOURCE OF TRUTH = TORCH_VERSION (+ ROCM_VERSION); everything else is ALIGNED to it:
+#   - amd-torch-device-gfx1151 and torchaudio share torch's version exactly
+#   - torchvision tracks torch as 0.(minor+15)  (torch 2.N -> torchvision 0.(N+15); 2.11 -> 0.26)
+# (pip left to itself picks the NEWEST torchvision, which is built for a newer torch — so we
+# derive it rather than let it float.) A torch bump needs only these two ARGs.
 ARG ROCM_WHL=https://repo.amd.com/rocm/whl-multi-arch/
 ARG TORCH_VERSION=2.11.0
 ARG ROCM_VERSION=7.14.0
-ARG TORCHVISION_VERSION=0.26.0
-ARG TORCHAUDIO_VERSION=2.11.0
-RUN python -m pip install --index-url ${ROCM_WHL} --extra-index-url https://pypi.org/simple \
+RUN set -e; \
+    TV_MINOR=$(( $(echo "${TORCH_VERSION}" | cut -d. -f2) + 15 )); \
+    TORCHVISION="0.${TV_MINOR}.0+rocm${ROCM_VERSION}"; \
+    echo "aligned to torch ${TORCH_VERSION}+rocm${ROCM_VERSION} -> torchvision=${TORCHVISION}, torchaudio=${TORCH_VERSION}+rocm${ROCM_VERSION}"; \
+    python -m pip install --index-url ${ROCM_WHL} --extra-index-url https://pypi.org/simple \
       "torch==${TORCH_VERSION}+rocm${ROCM_VERSION}" \
       "amd-torch-device-gfx1151==${TORCH_VERSION}+rocm${ROCM_VERSION}" \
       "rocm-sdk-devel==${ROCM_VERSION}" "rocm-sdk-device-gfx1151==${ROCM_VERSION}" \
-      "torchvision==${TORCHVISION_VERSION}+rocm${ROCM_VERSION}" \
-      "torchaudio==${TORCHAUDIO_VERSION}+rocm${ROCM_VERSION}"
+      "torchvision==${TORCHVISION}" \
+      "torchaudio==${TORCH_VERSION}+rocm${ROCM_VERSION}"
 RUN python -m pip install --upgrade cmake ninja numpy "setuptools-scm>=8" \
       "setuptools<80.0.0" scikit-build-core pybind11 numba scipy einops
 

--- a/README.md
+++ b/README.md
@@ -103,8 +103,13 @@ To manually create a toolbox that exposes the GPU and relaxes seccomp:
 toolbox create vllm \
   --image docker.io/kyuz0/vllm-therock-gfx1151:latest \
   -- --device /dev/dri --device /dev/kfd \
-  --group-add video --group-add render --security-opt seccomp=unconfined
+  --group-add keep-groups --security-opt seccomp=unconfined
 ```
+
+> [!IMPORTANT]
+> Use `--group-add keep-groups`, **not** `--group-add video --group-add render`. See
+> [GPU device permissions](#61-gpu-device-permissions) — the named groups do not grant GPU
+> access under rootless podman and can stop the container from starting at all.
 
 Enter it:
 
@@ -133,12 +138,17 @@ Ubuntu’s toolbox package still breaks GPU access, so use Distrobox instead:
 ```bash
 distrobox create -n vllm \
   --image docker.io/kyuz0/vllm-therock-gfx1151:latest \
-  --additional-flags "--device /dev/kfd --device /dev/dri --group-add video --group-add render --security-opt seccomp=unconfined"
+  --additional-flags "--device /dev/kfd --device /dev/dri --group-add keep-groups --security-opt seccomp=unconfined"
 
 distrobox enter vllm
 ```
 
-> **Verification:** Run `rocm-smi` to check GPU status.
+The Ubuntu / stable-ROCm image works the same way — swap the `--image` for
+`docker.io/kyuz0/vllm-rocm-gfx1151:latest`.
+
+> **Verification:** Run `rocm-smi` to check GPU status. It should print your GPU name (e.g.
+> `Radeon 8060S Graphics`). If it reports `get_name, Failed to load a library` or no device at
+> all, see [GPU device permissions](#61-gpu-device-permissions).
 
 ### Serving a Model (Easiest Way)
 
@@ -198,7 +208,61 @@ docker run -p 3000:3000 \
 
 This should work on any Strix Halo. For a complete list of available hardware, see: [Strix Halo Hardware Database](https://strixhalo-homelab.d7.wtf/Hardware)
 
-### 6.1 Test Configuration
+### 6.1 GPU Device Permissions
+
+The container needs access to `/dev/kfd` (the ROCm compute device) and `/dev/dri/renderD*`. On
+most distributions these ship as mode **0660 `root:render`**, so access is granted by group
+membership. Add yourself to the groups once (log out and back in afterwards):
+
+```bash
+sudo usermod -aG render,video "$USER"
+```
+
+**Then pass those groups into the container with `--group-add keep-groups`.**
+
+> [!WARNING]
+> Do **not** use `--group-add video --group-add render`. Under **rootless podman** — the default
+> for both toolbx and distrobox — a *named* `--group-add` is resolved against the **container's**
+> `/etc/group`, and the resulting gid lives inside the user namespace. It never maps to the
+> host's `render`/`video` gid, so it grants **no** access to `/dev/kfd`. Two failure modes follow:
+>
+> * **Container refuses to start**, if the image has no such group:
+>   `Error: ... unable to find group render: no matching entries in group file`
+> * **Container starts but has no GPU**: `/dev/kfd` returns `EACCES` and `rocm-smi` reports
+>   `get_name, Failed to load a library` with no device name.
+>
+> `keep-groups` (crun's `keep_original_groups`) passes your **real host** supplementary groups
+> through, which is what actually authorises the device.
+
+**Rootful Docker** has no user namespace, so numeric **host** gids work there instead:
+
+```bash
+docker run --device /dev/kfd --device /dev/dri \
+  --group-add "$(getent group render | cut -d: -f3)" \
+  --group-add "$(getent group video  | cut -d: -f3)" ...
+```
+
+**Headless / multi-user hosts** may prefer relaxing the device modes instead of managing groups:
+
+```bash
+# /etc/udev/rules.d/70-kfd.rules
+SUBSYSTEM=="kfd", KERNEL=="kfd", MODE="0666"
+SUBSYSTEM=="drm", KERNEL=="renderD*", MODE="0666"
+```
+
+Reload with `sudo udevadm control --reload && sudo udevadm trigger`. This makes the devices
+world-accessible, which removes the group requirement entirely — convenient on a single-user
+box, but it does grant every local user GPU access.
+
+**Quick diagnosis** from inside the container:
+
+```bash
+id                                  # do you actually have the host render/video gids?
+ls -l /dev/kfd /dev/dri/renderD128  # 0660 needs group access; 0666 needs nothing
+rocm-smi --showproductname          # should print your GPU name
+```
+
+### 6.2 Test Configuration
 
 | Component         | Specification                                               |
 | :---------------- | :---------------------------------------------------------- |
@@ -208,7 +272,7 @@ This should work on any Strix Halo. For a complete list of available hardware, s
 | **GPU Memory**    | 512 MB allocated in BIOS                                    |
 | **Host OS**       | Fedora 43, Linux 6.18.5-200.fc43.x86_64            |
 
-### 6.2 Kernel Parameters (tested on Fedora 42)
+### 6.3 Kernel Parameters (tested on Fedora 42)
 
 Add these boot parameters to enable unified memory while reserving a minimum of 4 GiB for the OS (max 124 GiB for iGPU):
 

--- a/rdma_cluster/setup_guide.md
+++ b/rdma_cluster/setup_guide.md
@@ -234,7 +234,11 @@ To install the toolbox on **both nodes**, run:
 2.  Detects if `/dev/infiniband` exists on your host.
 3.  Creates the toolbox with flags to expose:
     *   **iGPU Access**: `/dev/dri`, `/dev/kfd` (Required for ROCm)
-    *   **RDMA Access**: `/dev/infiniband`, `--group-add rdma`
+    *   **RDMA Access**: `/dev/infiniband`
+    *   **Group passthrough**: `--group-add keep-groups` — carries your host `render`, `video`
+        and `rdma` groups into the container. Named flags like `--group-add rdma` do **not**
+        work under rootless podman and abort the container when the image lacks that group;
+        see [GPU Device Permissions](../README.md#61-gpu-device-permissions).
     *   **Memory Pinning**: `--ulimit memlock=-1` (Required for DMA)
 
 ### 5.3 Verify RDMA Connection

--- a/rdma_cluster/troubleshooting_rccl.md
+++ b/rdma_cluster/troubleshooting_rccl.md
@@ -75,12 +75,15 @@ toolbox create vllm \
   --device /dev/dri \
   --device /dev/kfd \
   --device /dev/infiniband \
-  --group-add video \
-  --group-add render \
-  --group-add rdma \
+  --group-add keep-groups \
   --ulimit memlock=-1 \
   --security-opt seccomp=unconfined
 ```
+
+> `--group-add keep-groups` passes your host `render`/`video`/`rdma` groups through. Named
+> `--group-add video --group-add render --group-add rdma` does **not** work under rootless
+> podman and aborts the container if the image lacks the group — see
+> [GPU Device Permissions](../README.md#61-gpu-device-permissions).
 
 The following Dockerfile is used for the toolbox: https://github.com/kyuz0/amd-strix-halo-vllm-toolboxes/blob/main/Dockerfile
 

--- a/refresh_toolbox.sh
+++ b/refresh_toolbox.sh
@@ -2,8 +2,10 @@
 
 set -e
 
-TOOLBOX_NAME="vllm"
-IMAGE_REPO="docker.io/kyuz0/vllm-therock-gfx1151"
+TOOLBOX_NAME="${TOOLBOX_NAME:-vllm}"
+# Override to use a different image family, e.g. the Ubuntu / stable-ROCm one:
+#   IMAGE_REPO=docker.io/kyuz0/vllm-rocm-gfx1151 ./refresh_toolbox.sh latest
+IMAGE_REPO="${IMAGE_REPO:-docker.io/kyuz0/vllm-therock-gfx1151}"
 
 # --- Channel selection (latest / dev) ---
 resolve_channel() {
@@ -40,13 +42,23 @@ resolve_channel() {
 CHANNEL="$(resolve_channel "${1:-}")"
 IMAGE="${IMAGE_REPO}:${CHANNEL}"
 
-# Base options
-OPTIONS="--device /dev/dri --device /dev/kfd --group-add video --group-add render --security-opt seccomp=unconfined"
+# Base options.
+#
+# GPU access uses --group-add keep-groups, NOT --group-add video/render. Under rootless podman
+# (what toolbx and distrobox use by default) a named --group-add resolves against the
+# CONTAINER's /etc/group and the resulting gid lives inside the user namespace — it never maps
+# to the host's video/render gid, so it grants no access to /dev/kfd or /dev/dri at all. Worse,
+# if the name is absent from the image podman refuses to start the container outright
+# ("unable to find group <name>: no matching entries in group file").
+# keep-groups (crun's keep_original_groups) passes your real HOST supplementary groups through,
+# which is what actually authorises /dev/kfd on a stock 0660 root:render device.
+OPTIONS="--device /dev/dri --device /dev/kfd --group-add keep-groups --security-opt seccomp=unconfined"
 
 # Check for InfiniBand devices
 if [ -d "/dev/infiniband" ]; then
     echo "🔎 InfiniBand devices detected! Adding RDMA support..."
-    OPTIONS="$OPTIONS --device /dev/infiniband --group-add rdma --ulimit memlock=-1"
+    # No --group-add rdma needed: keep-groups already carries the host's rdma group through.
+    OPTIONS="$OPTIONS --device /dev/infiniband --ulimit memlock=-1"
 else
     echo "ℹ️  No InfiniBand devices detected."
 fi

--- a/scripts/patch_amdsmi.py
+++ b/scripts/patch_amdsmi.py
@@ -1,0 +1,112 @@
+"""Workaround for an amdsmi bug: VRAM total is the BIOS carveout on APUs.
+
+On AMD APUs (e.g. gfx1151 / Strix Halo) amdsmi reports the small dedicated BIOS VRAM
+carveout as the VRAM total, instead of the memory the GPU actually addresses:
+
+    amdsmi VRAM total   ->     536,870,912   (0.50 GiB)   <- BIOS carveout
+    amdsmi GTT total    -> 118,111,600,640   (110.00 GiB) <- unified pool
+    KFD mem_banks/0     -> 118,111,600,640   (110.00 GiB) <- the driver's truth
+    HIP totalGlobalMem  -> 118,111,600,640   (110.00 GiB)
+
+sysfs `mem_info_vram_total` only exposes the carveout, and
+`rsmi_dev_memory_total_get()` only consults KFD when that read fails or returns 0 --
+on an APU it "succeeds" with the carveout, so KFD is never asked.
+
+Consumers that size a memory budget from the VRAM total therefore see 0.5 GiB on a
+110 GiB device. vLLM's ROCm platform does exactly this in
+`RocmPlatform.get_device_total_memory()`.
+
+The bug is in amdsmi, not in its consumers, so patch it here rather than in vLLM.
+This mirrors the fix proposed upstream (prefer the KFD/GTT total when it exceeds the
+sysfs VRAM total):
+
+    https://github.com/ROCm/rocm-systems/pull/8419   (APU case proposed in a comment)
+    https://github.com/ROCm/rocm-systems/issues/8476 (APUs aren't identifiable via amdsmi)
+
+Delete this script once the fix ships in a ROCm release. It is idempotent and a no-op
+if amdsmi already reports the correct total.
+"""
+
+import importlib.util
+import os
+import sys
+
+# The workaround inserted just before `return total.value`. Shape-independent.
+_WORKAROUND = """
+    # --- Strix Halo / APU workaround (see scripts/patch_amdsmi.py) --------------
+    # On APUs the VRAM total is only the small BIOS carveout, while the GPU
+    # addresses the unified pool that the GTT total (and KFD mem_banks) reports.
+    # Prefer the larger of the two, mirroring the fix proposed upstream in
+    # ROCm/rocm-systems#8419. Remove once that ships in a ROCm release.
+    if mem_type == AmdSmiMemoryType.VRAM:
+        try:
+            _gtt = ctypes.c_uint64()
+            if (
+                amdsmi_wrapper.amdsmi_get_gpu_memory_total(
+                    processor_handle, AmdSmiMemoryType.GTT, ctypes.byref(_gtt)
+                )
+                == 0
+                and _gtt.value > total.value
+            ):
+                return _gtt.value
+        except Exception:  # never let the workaround break a working query
+            pass
+    # --- end workaround --------------------------------------------------------
+
+    return total.value"""
+
+# amdsmi_get_gpu_memory_total ends with a `_check_res(...)` on the C call then
+# `return total.value`. The `_check_res(...)` block is formatted differently across
+# ROCm releases (multi-line pre-7.14, single-line in 7.14+), so support both.
+_CHECK_RES_MULTILINE = """    _check_res(
+        amdsmi_wrapper.amdsmi_get_gpu_memory_total(
+            processor_handle, mem_type, ctypes.byref(total))
+    )
+"""
+_CHECK_RES_SINGLELINE = """    _check_res(
+        amdsmi_wrapper.amdsmi_get_gpu_memory_total(processor_handle, mem_type, ctypes.byref(total))
+    )
+"""
+
+# (anchor, replacement) pairs, tried in order.
+PATCHES = [
+    (block + "\n    return total.value", block + _WORKAROUND)
+    for block in (_CHECK_RES_MULTILINE, _CHECK_RES_SINGLELINE)
+]
+
+MARKER = "Strix Halo / APU workaround"
+
+
+def main() -> int:
+    spec = importlib.util.find_spec("amdsmi")
+    if spec is None or not spec.origin:
+        print(" -> amdsmi not installed; nothing to patch", file=sys.stderr)
+        return 1
+
+    path = os.path.join(os.path.dirname(spec.origin), "amdsmi_interface.py")
+    txt = open(path).read()
+
+    if MARKER in txt:
+        print(" -> amdsmi already patched (idempotent no-op)")
+        return 0
+
+    for anchor, replacement in PATCHES:
+        if anchor in txt:
+            open(path, "w").write(txt.replace(anchor, replacement, 1))
+            print(" -> Patched amdsmi_get_gpu_memory_total (APU: prefer GTT over VRAM carveout)")
+            return 0
+
+    # No known shape matched: amdsmi changed again, or the upstream fix has landed.
+    # Fail loudly rather than silently ship an image that OOMs on APUs at runtime.
+    print(
+        " -> amdsmi_get_gpu_memory_total does not match any known shape; "
+        "the VRAM-carveout workaround was NOT applied. If ROCm/rocm-systems#8419 has "
+        "landed (VRAM total now reports the full pool) this script is obsolete -- verify "
+        "and drop it; otherwise the anchor needs updating for the new amdsmi shape.",
+        file=sys.stderr,
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/patch_strix.py
+++ b/scripts/patch_strix.py
@@ -24,36 +24,26 @@ def patch_vllm():
             p_spinloop.write_text(txt)
             print(" -> Patched csrc/spinloop.cpp (mwaitxintrin.h -> x86intrin.h for clang)")
 
-    # Patch 1: vllm/platforms/__init__.py (amdsmi monkey patch — PROVEN working for 5 months)
-    # Comment out real amdsmi imports and replace with pass stubs.
-    # The actual amdsmi library doesn't work on Strix Halo APUs in containers.
-    p_init = Path('vllm/platforms/__init__.py')
-    if p_init.exists():
-        txt = p_init.read_text()
-        txt = txt.replace('import amdsmi', '# import amdsmi')
-        txt = re.sub(r'is_rocm = .*', 'is_rocm = True', txt)
-        txt = re.sub(r'if len\(amdsmi\.amdsmi_get_processor_handles\(\)\) > 0:', 'if True:', txt)
-        txt = txt.replace('amdsmi.amdsmi_init()', 'pass')
-        txt = txt.replace('amdsmi.amdsmi_shut_down()', 'pass')
-        p_init.write_text(txt)
-        print(" -> Patched vllm/platforms/__init__.py (amdsmi disabled, is_rocm forced True)")
-
-    # Patch 1.5: vllm/platforms/rocm.py (MagicMock amdsmi + force gfx1151)
-    # Prepend MagicMock so any remaining amdsmi references in rocm.py silently succeed.
-    p_rocm_plat = Path('vllm/platforms/rocm.py')
-    if p_rocm_plat.exists():
-        txt = p_rocm_plat.read_text()
-        # Add MagicMock header if not already present
-        if 'sys.modules["amdsmi"] = MagicMock()' not in txt:
-            header = 'import sys\nfrom unittest.mock import MagicMock\nsys.modules["amdsmi"] = MagicMock()\n'
-            txt = header + txt
-        # Force arch detection
-        if 'def _get_gcn_arch() -> str:\n    return "gfx1151"' not in txt:
-            txt = txt.replace('def _get_gcn_arch() -> str:', 'def _get_gcn_arch() -> str:\n    return "gfx1151"\n\ndef _old_get_gcn_arch() -> str:')
-            txt = re.sub(r'device_type = .*', 'device_type = "rocm"', txt)
-            txt = re.sub(r'device_name = .*', 'device_name = "gfx1151"', txt)
-        p_rocm_plat.write_text(txt)
-        print(" -> Patched vllm/platforms/rocm.py (MagicMock amdsmi + forced gfx1151)")
+    # NOTE: the former Patch 1 / Patch 1.5 (comment out `import amdsmi`, stub it with a
+    # MagicMock, and force the GCN arch to gfx1151) are GONE.
+    #
+    # They existed because "the actual amdsmi library doesn't work on Strix Halo APUs in
+    # containers". That is no longer true: the amdsmi python bindings ship with ROCm
+    # (/opt/rocm/share/amd_smi) and work fine on gfx1151 -- they were simply never
+    # installed, so `from amdsmi import ...` failed and everything had to be stubbed.
+    # The Dockerfile now installs them, and vLLM resolves the arch and device name on its
+    # own (verified: _query_gcn_arch_from_amdsmi() -> 'gfx1151', device name ->
+    # AMD_Radeon_8060S).
+    #
+    # Keeping the MagicMock was also actively harmful: a mock call never raises, so vLLM's
+    # `try: <amdsmi> except: <fallback>` helpers never reached their fallback and the mock
+    # leaked into real use. vLLM >= 0.25.1 calls get_device_total_memory() from
+    # get_batch_defaults() at engine-config time and does `device_memory >= 70*GiB`, which
+    # raised `TypeError: '>=' MagicMock vs int` and crashed startup for EVERY model.
+    #
+    # The one genuine bug left is in amdsmi itself (it reports the 512 MiB BIOS VRAM
+    # carveout as the VRAM total on APUs); that is worked around in scripts/patch_amdsmi.py,
+    # at the layer where the bug actually is, so vLLM needs no memory patch at all.
 
     # Patch 2: _aiter_ops.py (Enable AITER on gfx1x, disable FP8 linear)
     p_aiter = Path('vllm/_aiter_ops.py')
@@ -65,27 +55,26 @@ def patch_vllm():
             txt = txt.replace("from vllm.platforms import current_platform", 
                               "from vllm.platforms import current_platform\nfrom vllm.platforms.rocm import on_gfx1x")
 
-        # Extend is_aiter_found_and_supported
+        # Extend is_aiter_found_and_supported. Scope the call-site replace to that
+        # function's `return on_mi3xx()` — a bare "on_mi3xx()" replace also flipped
+        # is_linear_hipbmm_enabled on gfx1x (unintended; found in the v0.26.0 audit).
         if "or on_gfx1x()" not in txt:
             txt = txt.replace("import on_mi3xx", "import on_mi3xx, on_gfx1x")
-            txt = txt.replace("on_mi3xx()", "(on_mi3xx() or on_gfx1x())")
-            
+            txt = txt.replace("return on_mi3xx()", "return (on_mi3xx() or on_gfx1x())")
+
         # Disable FP8 linear
         if "is_linear_fp8_enabled" in txt:
             txt = re.sub(
-                r'(def is_linear_fp8_enabled.*?:\n\s+return) (.*?)\n', 
-                r'\1 False\n', 
+                r'(def is_linear_fp8_enabled.*?:\n\s+return) (.*?)\n',
+                r'\1 False\n',
                 txt, count=1, flags=re.DOTALL
             )
-            
-        # Disable AITER RMSNorm on gfx1x (CUDA Graph hang)
-        if "is_rmsnorm_enabled" in txt:
-            txt = re.sub(
-                r'(def is_rmsnorm_enabled.*?:\n\s+return) (cls\._AITER_ENABLED and cls\._RMSNORM_ENABLED)\n', 
-                r'\1 \2 and not getattr(on_gfx1x, "__call__", lambda: False)()\n', 
-                txt, count=1, flags=re.DOTALL
-            )
-            
+
+        # NOTE: the former "disable AITER RMSNorm" patch (is_rmsnorm_enabled) was REMOVED.
+        # vLLM >=0.26.0 deleted that method; AITER RMSNorm is now gated solely by the
+        # IrOpPriorityConfig bypass in Patch 5 (`rms_norm = ["aiter"]+default` -> `default`
+        # on gfx1x). Re-adding an _aiter_ops gate here would be a silent no-op. (v0.26.0 audit.)
+
         # Disable AITER Fused MoE on gfx1x (due to hundreds of CDNA-specific dpp_mov assembly conflicts)
         if "is_fused_moe_enabled" in txt:
             txt = re.sub(
@@ -127,32 +116,20 @@ def patch_vllm():
     p_rocm = Path('vllm/platforms/rocm.py')
     if p_rocm.exists():
         txt = p_rocm.read_text()
-        
-        # Legacy vLLM < 0.19 fallback
-        if "if is_aiter_found_and_supported():\n            custom_ops.append(\"+rms_norm\")" in txt:
-            txt = txt.replace(
-                "if is_aiter_found_and_supported():\n            custom_ops.append(\"+rms_norm\")",
-                "if is_aiter_found_and_supported() and not getattr(self, 'on_gfx1x', lambda: False)():\n            custom_ops.append(\"+rms_norm\")"
-            )
-        
-        # Modern vLLM 0.19+ struct (compilation_config.custom_ops)
-        elif "compilation_config.custom_ops.append(\"+rms_norm\")" in txt:
-            if "if not getattr(self, \"on_gfx1x\", lambda: False)():" not in txt:
-                txt = re.sub(
-                    r'(\s+)compilation_config\.custom_ops\.append\("\+rms_norm"\)',
-                    r'\1if not getattr(self, "on_gfx1x", lambda: False)():\n\1    compilation_config.custom_ops.append("+rms_norm")',
-                    txt
-                )
-                
-        # Modern vLLM 0.19.2rc1+ IrOpPriorityConfig bypass
+
+        # RMSNorm off AITER on gfx1x via the IrOpPriorityConfig list — the only live anchor
+        # in vLLM >=0.26.0. The former legacy `custom_ops.append("+rms_norm")` variants
+        # (vLLM <0.19, and the 0.19+ compilation_config form) were REMOVED: dead anchors in
+        # the versions we build, and the 0.19+ string now only appears in an unrelated SP/PP
+        # path in config/vllm.py that must NOT be touched. (v0.26.0 audit.)
         if 'rms_norm = ["aiter"] + default' in txt:
             txt = txt.replace(
                 'rms_norm = ["aiter"] + default',
                 'rms_norm = ["aiter"] + default if not on_gfx1x() else default'
             )
-            
+
         p_rocm.write_text(txt)
-        print(" -> Patched vllm/platforms/rocm.py (custom_ops & IrOpPriorityConfig rms_norm bypassed on gfx1x)")
+        print(" -> Patched vllm/platforms/rocm.py (IrOpPriorityConfig rms_norm bypassed on gfx1x)")
 
     # Patch 6: vllm/compilation/passes/fusion/rocm_aiter_fusion.py (duplicate pattern bypass)
     p_fusion = Path('vllm/compilation/passes/fusion/rocm_aiter_fusion.py')
@@ -167,18 +144,9 @@ def patch_vllm():
             p_fusion.write_text(txt)
             print(" -> Patched vllm/compilation/passes/fusion/rocm_aiter_fusion.py (skip_duplicates)")
 
-    # Patch 7: Triton backend AttrsDescriptor repr
-    for sp in site.getsitepackages():
-        triton_compiler = Path(sp) / "triton/backends/compiler.py"
-        if triton_compiler.exists():
-            txt = triton_compiler.read_text()
-            if "def __repr__(self):" not in txt:
-                txt = txt.replace(
-                    "def to_dict(self):", 
-                    "def __repr__(self):\n        return f'AttrsDescriptor.from_dict({self.to_dict()!r})'\n\n    def to_dict(self):"
-                )
-                triton_compiler.write_text(txt)
-                print(f" -> Patched {triton_compiler} (AttrsDescriptor repr)")
+    # NOTE: the former "Triton AttrsDescriptor repr" patch was REMOVED — the AttrsDescriptor
+    # class no longer exists in Triton >=3.6.0 (deleted upstream), so the patch was a
+    # permanent silent no-op on the triton we ship. (v0.26.0 / triton-3.6.0 audit.)
 
     # Patch 7: aiter JIT path fix — aiter builds .so files into ~/.aiter/jit/
     # but importlib.import_module("aiter.jit.<module>") only looks in the
@@ -219,7 +187,7 @@ if _os.path.isdir(_jit_cache) and _jit_cache not in __path__:
         soft_import = (
             f"{indent}try:\n"
             f"{indent}    {hard_import_bare}\n"
-            f"{indent}except (ImportError, KeyError, ModuleNotFoundError):\n"
+            f"{indent}except (ImportError, KeyError, ModuleNotFoundError, RuntimeError):\n"
             f"{indent}    flash_attn_gpu = None"
         )
         txt = txt.replace(original_line, soft_import)
@@ -237,35 +205,12 @@ if _os.path.isdir(_jit_cache) and _jit_cache not in __path__:
         if fa_iface.exists():
             _patch_flash_interface(fa_iface)
 
-    # Patch 9: Allow Triton MoE kernels on gfx11xx (Strix Halo)
-    # vLLM recently capped MXFP4 Triton MoE kernels to < (11, 0) which excludes RDNA3.5 (11.x)
-    for p_triton in [
-        Path('vllm/model_executor/layers/fused_moe/experts/gpt_oss_triton_kernels_moe.py'),
-        Path('vllm/model_executor/layers/fused_moe/oracle/mxfp4.py')
-    ]:
-        if p_triton.exists():
-            txt = p_triton.read_text()
-            if "cap.minor) < (11, 0)" in txt:
-                txt = txt.replace("cap.minor) < (11, 0)", "cap.minor) < (12, 0)")
-            if "capability() < (11, 0)" in txt:
-                txt = txt.replace("capability() < (11, 0)", "capability() < (12, 0)")
-            p_triton.write_text(txt)
-            print(f" -> Patched {p_triton} (Triton MoE on gfx11xx)")
-
-    # Patch 11: moe_wna16.py — fix tp_size AttributeError on RoutedExperts
-    # vLLM refactored FusedMoE and moved tp_size out of RoutedExperts (the
-    # weight container) into FusedMoEConfig. But moe_wna16_weight_loader still
-    # accesses `layer.tp_size` which crashes AWQ MoE models (Qwen3.5 etc.)
-    # that fall back from AWQMoeMarlin to the WNA16 path.
-    # Fix: use get_tp_group().world_size which is always available.
-    # https://github.com/vllm-project/vllm/issues/45403
-    p_moe_wna16 = Path('vllm/model_executor/layers/quantization/moe_wna16.py')
-    if p_moe_wna16.exists():
-        txt = p_moe_wna16.read_text()
-        if 'layer.tp_size' in txt:
-            txt = txt.replace('layer.tp_size', 'get_tp_group().world_size')
-            p_moe_wna16.write_text(txt)
-            print(" -> Patched moe_wna16.py (layer.tp_size -> get_tp_group().world_size)")
+    # NOTE: the former "Triton MoE on gfx11xx" cap-bump patch was REMOVED. vLLM >=0.26.0
+    # already enables the OAI Triton MoE kernels on gfx11xx via the ROCm on_gfx1x()/on_gfx9()
+    # gate (_triton_kernel_moe_supports_current_device); the old `< (11, 0)` cap is gone from
+    # oracle/mxfp4.py, and the only remaining `(11, 0)` match sits in a CUDA-only branch of
+    # gpt_oss_triton_kernels_moe.py where our replace mis-fired (inert on ROCm, but a wrong
+    # edit to the CUDA gate). Dropped entirely. (v0.26.0 audit.)
 
     # Patch 11: RocmPlatform.is_integrated_gpu override (smart UMA detection)
     # Upstream vLLM PR #35356 (merged 2026-04-13) added Platform.is_integrated_gpu()


### PR DESCRIPTION
Replaces the previous Ubuntu-based image with one built entirely from AMD's per-arch **release** wheels at `https://repo.amd.com/rocm/whl-multi-arch/` (TheRock multi-arch **device-package** layout — **ROCm 7.14**: `torch 2.11.0+rocm7.14.0` + a per-arch `amd-torch-device-gfx1151` / `rocm-sdk-device-gfx1151`; the legacy per-arch `whl/gfx1151/` index is frozen at 7.13.0). Minimal `ubuntu:24.04` + pip stable torch brings its own matched `_rocm_sdk_core`, so no system-vs-pip ABI mismatch — off the nightly treadmill.

**What's in it**
- Multi-stage, **~9 GB slim**. `build-ubuntu-stable.yml` auto-resolves the newest stable gfx1151 torch + latest vLLM release tag → publishes `vllm-rocm-gfx1151`.
- **Vision works** — ROCm flash-attention + aiter Triton ViT kernels + #40289 (ViT on Flash Attention Triton, not the SDPA path that OOMs).
- Stays on **ubuntu 24.04 / py3.12** — `amd-quark` has no py3.14 release yet (blocks 26.04).

**Verified end-to-end on the CI-built 7.14 image** (`rocm7.14.0-torch2.11.0-vllm0.26.0`) — both models serve text + vision on-GPU (ViT on Flash-Attention-Triton, not SDPA; `torch.cuda` on ROCm 7.14, Radeon 8060S):

| Model | Text | Vision | Prefill | Decode |
|---|---|---|---|---|
| `cyankiwi/Qwen3.6-27B-AWQ-INT4` (dense) | ✓ | ✓ | ~281 tok/s | ~3.5 tok/s |
| `cyankiwi/Qwen3.6-35B-A3B-AWQ-4bit` (MoE) | ✓ | ✓ | ~790 tok/s | ~27 tok/s |

*(single-stream, `--gpu-memory-utilization 0.4` on a shared node; vLLM's strength is batched throughput.)*

**Triton cache:** first serve autotunes the GDN + ViT kernels on the GPU (a few min). We deliberately don't bake a cache (it goes stale under auto-resolve) — mount a host dir at `TRITON_CACHE_DIR` (`/opt/triton_cache`) to persist it across runs.

**`patch_strix.py` changes (shared script):**
- **Removes the obsolete amdsmi MagicMock stub.** This image installs real amdsmi (pip rocm-sdk) and fixes its APU VRAM reporting (`patch_amdsmi.py`), so the mock isn't just unnecessary here — it's harmful: it shadows the real amdsmi at runtime, nullifying the 110 GiB fix and reintroducing the `">= 70 GiB"` MagicMock `TypeError` at startup on vLLM ≥0.25.1.
- **Drops sub-patches whose anchors no longer exist in current vLLM** (`is_rmsnorm_enabled`, legacy `+rms_norm`, Triton `AttrsDescriptor` repr, the Triton-MoE `(11,0)` cap) and scopes/hardens the rest (v0.26.0 audit).

> **⚠️ Fedora/TheRock heads-up:** `patch_strix.py` is shared, and that image has **no real amdsmi module** — it relies on the mock — so this change **degrades the Fedora image** (its `import amdsmi` would fail at startup). Flagging it openly: it seemed acceptable given the plan to make this image the main one and deprecate Fedora, but if you'd rather keep Fedora working in the interim we can make the mock **conditional** (applied only when real amdsmi is absent) so one `patch_strix` serves both — your call.

---

**Container-permission fixes** (users reported the README workflow not working)

I'd only ever driven these images with hand-rolled `podman run`, so I exercised the *documented* toolbx/distrobox flows for the first time and found three defects. One root cause behind all of them: podman resolves a **named** `--group-add` against the **container's** `/etc/group`, and under **rootless** podman the resulting gid lives inside the user namespace — it never maps to the host's `render`/`video` gid.

Measured on a stock `0660 root:render` `/dev/kfd` (the Fedora/Ubuntu default), same image, only the flags differ:

| flags | /dev/kfd | renderD128 | rocm-smi |
|---|---|---|---|
| `--group-add video --group-add render` | **EACCES** | **EACCES** | `get_name, Failed to load a library` |
| `--group-add keep-groups` | OPEN-OK | OPEN-OK | `Radeon 8060S Graphics` |

1. **Ubuntu image had no `render` group** → every documented `toolbox create` / `distrobox create` / `podman run` **failed to start outright**: `unable to find group render: no matching entries in group file`. Added `render` at gid 105 (Fedora parity).
2. **Fedora image has no `rdma` group** → `./refresh_toolbox.sh` **aborts on any InfiniBand host**, since it adds `--group-add rdma` whenever `/dev/infiniband` exists. The RDMA clustering path could not be entered at all. Added `rdma` at gid 101.
3. **`rocm-smi` could not name the GPU (Ubuntu image)** — amdsmi `dlopen()`s the *unversioned* `libdrm_amdgpu.so`, which ships only in `libdrm-dev`. Symlinked to the `.so.1` that `libdrm-amdgpu1` already provides. Since `rocm-smi` is the README's own verification step, a working GPU read as broken. Also added `sudo` (toolbx/distrobox use it for in-container user setup).

Scripts and docs now use `--group-add keep-groups` (`refresh_toolbox.sh`, both quickstarts, the RDMA setup guide, the RCCL troubleshooting doc), plus a new **README §6.1 "GPU Device Permissions"**: group membership, why named `--group-add` fails rootless, the numeric-gid form that *does* work under rootful Docker, an optional `0666` udev rule, and a three-command diagnosis.

Why this went unnoticed for so long: **distrobox silently injects `run.oci.keep_original_groups=1`** regardless of the flags handed to it — verified identical results with and without the group flags — so the distrobox quickstart appeared to work while the plain-podman path did not. And any host carrying a udev rule that relaxes `/dev/kfd` to `0666` (ours does) masks the problem entirely.

**Verified with the fixed image through the documented distrobox flow:** container starts, `rocm-smi` → `Radeon 8060S Graphics`, `torch.cuda.is_available()` True plus a real GPU matmul, and a full `vllm serve` of `cyankiwi/Qwen3.6-35B-A3B-AWQ-4bit` answering a chat completion (ready in 231 s on a warm Triton cache).

> **Multi-node caveat, for when this image takes over:** it carries stock ROCm `librccl.so.1` plus `libibverbs`/`librdmacm`, but **not** your custom gfx1151 RDMA-patched RCCL. Single-node is verified; RDMA/RoCE clustering on this image is **untested** and may need that patched `librccl.so` carried across. `refresh_toolbox.sh` now honours `IMAGE_REPO`/`TOOLBOX_NAME` env overrides so the same script can drive either image family for testing.

**Scope:** full replacement of the previous Ubuntu images. Adds `Dockerfile.ubuntu-repoamd`, `build-ubuntu-stable.yml`, `scripts/patch_amdsmi.py`, and updates the shared `scripts/patch_strix.py` (see the Fedora note above). Also fixes the container-permission defects above in `Dockerfile` (Fedora `rdma` group), `refresh_toolbox.sh`, `README.md` and the two `rdma_cluster/` docs. Supersedes #63.
