### PR TITLE
Fix BnB, enable AWQ int4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,9 +40,12 @@ WORKDIR /opt
 COPY scripts/patch_aiter_headers.py /opt/patch_aiter_headers.py
 RUN python -m pip install --upgrade cmake ninja packaging wheel numpy "setuptools-scm>=8" "setuptools<80.0.0" scikit-build-core pybind11 numba scipy
 
+# AWQ support: conch-triton-kernels for AWQMarlin-on-ROCm (PR #36505).
+RUN python -m pip install conch-triton-kernels==1.3
 
 # Flash-Attention & AITER
-ENV FLASH_ATTENTION_TRITON_AMD_ENABLE="TRUE"
+ENV FLASH_ATTENTION_TRITON_AMD_ENABLE="TRUE" \
+    VLLM_USE_TRITON_AWQ=1
 ENV LD_LIBRARY_PATH="/opt/rocm/lib:/opt/rocm/lib64:$LD_LIBRARY_PATH"
 
 RUN git clone https://github.com/ROCm/flash-attention.git && \
@@ -77,14 +80,13 @@ RUN lib_sp=/opt/venv/lib/python3.12/site-packages; \
   fi
 
 # 6. Clone vLLM
-# Optional: pin to a specific vLLM commit for reproducible builds.
-# Defaults to empty (tracks upstream HEAD). Override with --build-arg VLLM_COMMIT=<sha>.
+# Track HEAD for latest fixes. Override with --build-arg VLLM_COMMIT=<sha>.
 ARG VLLM_COMMIT=
 RUN git clone https://github.com/vllm-project/vllm.git /opt/vllm
 WORKDIR /opt/vllm
 RUN if [ -n "$VLLM_COMMIT" ]; then \
   echo "Pinning vLLM to commit $VLLM_COMMIT" && git checkout "$VLLM_COMMIT"; \
-  fi
+  else echo "Tracking vLLM HEAD: $(git rev-parse --short HEAD)"; fi
 
 # --- PATCHING ---
 COPY scripts/patch_strix.py /opt/vllm/patch_strix.py
@@ -140,23 +142,18 @@ RUN export HIP_DEVICE_LIB_PATH=$(find /opt/rocm -type d -name bitcode -print -qu
 
 RUN python -m pip install ray
 
-# --- bitsandbytes (ROCm) ---
+# --- bitsandbytes ---
+# Official bitsandbytes repo (bitsandbytes-foundation) with proper gfx1151 support.
 WORKDIR /opt
-RUN git clone -b rocm_enabled_multi_backend https://github.com/ROCm/bitsandbytes.git
+RUN git clone https://github.com/bitsandbytes-foundation/bitsandbytes.git /opt/bitsandbytes
 WORKDIR /opt/bitsandbytes
-
-# Explicitly set HIP_PLATFORM (Docker ENV, not /etc/profile)
-ENV HIP_PLATFORM="amd"
-ENV CMAKE_PREFIX_PATH="/opt/rocm"
-
-# Force CMake to use the System ROCm Compiler (/opt/rocm/llvm/bin/clang++)
 RUN cmake -S . \
-  -DGPU_TARGETS="gfx1151" \
-  -DBNB_ROCM_ARCH="gfx1151" \
-  -DCOMPUTE_BACKEND=hip \
-  -DCMAKE_HIP_COMPILER=/opt/rocm/llvm/bin/clang++ \
-  -DCMAKE_CXX_COMPILER=/opt/rocm/llvm/bin/clang++ \
-  && \
+    -DCOMPUTE_BACKEND=hip \
+    -DCMAKE_HIP_COMPILER=/opt/rocm/llvm/bin/clang++ \
+    -DCMAKE_CXX_COMPILER=/opt/rocm/llvm/bin/clang++ \
+    -DBNB_ROCM_ARCH="gfx1151" \
+    -DGPU_TARGETS="gfx1151" \
+    && \
   make -j$(nproc) && \
   python -m pip install --no-cache-dir . --no-build-isolation --no-deps && \
   (find /opt/venv -type f -name "*.so" -exec strip -s {} + 2>/dev/null || true) && \

--- a/scripts/patch_strix.py
+++ b/scripts/patch_strix.py
@@ -38,14 +38,29 @@ def patch_vllm():
         p_init.write_text(txt)
         print(" -> Patched vllm/platforms/__init__.py (amdsmi disabled, is_rocm forced True)")
 
-    # Patch 1.5: vllm/platforms/rocm.py (MagicMock amdsmi + force gfx1151)
-    # Prepend MagicMock so any remaining amdsmi references in rocm.py silently succeed.
+    # Patch 1.5: vllm/platforms/rocm.py (amdsmi mock + force gfx1151)
+    # Replace real amdsmi with a minimal mock that returns proper values for
+    # the specific functions vLLM calls, so device memory queries fall through
+    # to the torch.cuda fallback instead of returning a MagicMock.
     p_rocm_plat = Path('vllm/platforms/rocm.py')
     if p_rocm_plat.exists():
         txt = p_rocm_plat.read_text()
-        # Add MagicMock header if not already present
-        if 'sys.modules["amdsmi"] = MagicMock()' not in txt:
-            header = 'import sys\nfrom unittest.mock import MagicMock\nsys.modules["amdsmi"] = MagicMock()\n'
+        # Add amdsmi mock header if not already present
+        if 'sys.modules["amdsmi"] = _AmdsmiMock()' not in txt:
+            header = (
+                'import sys\n'
+                'from unittest.mock import MagicMock\n'
+                'class _AmdsmiMock:\n'
+                '    def amdsmi_get_processor_handles(self):\n'
+                '        raise RuntimeError("amdsmi not available on Strix Halo")\n'
+                '    def amdsmi_get_gpu_memory_total(self, handle, mem_type):\n'
+                '        raise RuntimeError("amdsmi not available on Strix Halo")\n'
+                '    def amdsmi_get_gpu_gcn_arch(self, handle):\n'
+                '        return "gfx1151"\n'
+                '    def __getattr__(self, name):\n'
+                '        return MagicMock()\n'
+                'sys.modules["amdsmi"] = _AmdsmiMock()\n'
+            )
             txt = header + txt
         # Force arch detection
         if 'def _get_gcn_arch() -> str:\n    return "gfx1151"' not in txt:
@@ -53,7 +68,7 @@ def patch_vllm():
             txt = re.sub(r'device_type = .*', 'device_type = "rocm"', txt)
             txt = re.sub(r'device_name = .*', 'device_name = "gfx1151"', txt)
         p_rocm_plat.write_text(txt)
-        print(" -> Patched vllm/platforms/rocm.py (MagicMock amdsmi + forced gfx1151)")
+        print(" -> Patched vllm/platforms/rocm.py (_AmdsmiMock + forced gfx1151)")
 
     # Patch 2: _aiter_ops.py (Enable AITER on gfx1x, disable FP8 linear)
     p_aiter = Path('vllm/_aiter_ops.py')


### PR DESCRIPTION

- ROCm BnB branch ref in head is gone, most of what's at the ROCm fork appears to be upstreamed, so switched to the mainline, seems ok?
- Started an exploration on bringing hec-ovi/vllm-awq4-qwen in for the awq support, but discovered along the way there's already AWQ support now? Mostly comes down to adding the dependencies.
- Some other noise that maybe isn't needed... (meaningless reshuffles, maybe unnecessary mock change?)

Can confirm all of the following work for at least the low param qwen3.5 i was doing initial tests with.
- fp16 -> bnb on load
- the fpf8 already part of the build
- the awq4 model