### PR TITLE
Drop the local #40289 ViT-detection patch (upstream in vLLM > v0.26.0)

### DIFF
--- a/Dockerfile.ubuntu-repoamd
+++ b/Dockerfile.ubuntu-repoamd
@@ -9,7 +9,7 @@
 #
 # Vision: gfx1151 vLLM would fall back to Torch SDPA for the ViT encoder (OOMs at 256 GiB),
 # so we build ROCm flash-attention + aiter Triton kernels and enable them
-# (FLASH_ATTENTION_TRITON_AMD_ENABLE + PR #40289 detection patch). aiter's C++ JIT module is
+# (FLASH_ATTENTION_TRITON_AMD_ENABLE). aiter's C++ JIT module is
 # pre-warmed at build so the dev SDK can be dropped while vision still works at runtime.
 #
 # BASE = 24.04 / py3.12: 26.04 ships py3.14 but vLLM's amd-quark dep has no py3.14 wheel yet.
@@ -108,35 +108,6 @@ RUN ROOT=$(rocm-sdk path --root) && \
     python -m pip install /tmp/dist/*.whl && rm -rf /tmp/dist
 RUN python -m pip install ray
 
-# #40289 (required): this flash-attn build ships the Triton-AMD kernels at the aiter
-# location, so make flash_attn_triton_available() detect them there (else ViT -> SDPA OOM).
-# Target the INSTALLED venv copy via sysconfig purelib — NOT find_spec("vllm"), which at this
-# WORKDIR (/opt/vllm) resolves to the source tree that gets rm -rf'd, leaving the shipped
-# copy unpatched (cost us a broken CI image).
-RUN python - <<'PY'
-import os, sysconfig
-p = os.path.join(sysconfig.get_paths()["purelib"], "vllm", "platforms", "rocm.py")
-assert os.path.exists(p), f"installed vllm rocm.py not found at {p}"
-s = open(p).read()
-old = '''        if find_spec("flash_attn") is None:
-            return False
-        if find_spec("flash_attn.flash_attn_triton_amd") is None:
-            return False'''
-new = '''        def _has(n):
-            try:
-                return find_spec(n) is not None
-            except (ImportError, ValueError):
-                return False
-        if not (_has("flash_attn.flash_attn_triton_amd")
-                or _has("aiter.ops.triton._triton_kernels.flash_attn_triton_amd")):
-            return False'''
-if old in s:
-    open(p,"w").write(s.replace(old,new,1)); print("patched rocm.py ViT detection (#40289)")
-elif "aiter.ops.triton._triton_kernels.flash_attn_triton_amd" in s:
-    print("rocm.py already detects the aiter location; no patch needed")
-else:
-    raise SystemExit("ERROR: rocm.py flash_attn_triton_available anchor not found")
-PY
 
 # --- SLIM: pre-warm aiter's C++ JIT (module_aiter_enum) while hipcc is present, then drop
 #     the 12 GB dev SDK. Vision still works at runtime (JIT cached; git in runtime image).
@@ -184,12 +155,13 @@ RUN groupadd -f -g 105 render \
 
 COPY --from=builder /opt/venv /opt/venv
 
-# Fail-fast: the ViT flash-attn detection MUST reference the aiter kernel location (#40289),
-# else vision silently falls back to Torch SDPA and OOMs. Guards against a stale buildcache
-# layer shipping an unpatched rocm.py (this cost us a broken CI image once).
+# Fail-fast: the ViT flash-attn detection MUST reference the aiter kernel location, else
+# vision silently falls back to Torch SDPA and OOMs. Also guards against a stale buildcache
+# layer (this cost us a broken CI image once).
 RUN grep -q "aiter.ops.triton._triton_kernels.flash_attn_triton_amd" \
       /opt/venv/lib/python3.12/site-packages/vllm/platforms/rocm.py \
-    || { echo "ERROR: rocm.py ViT flash-attn detection is NOT patched for aiter (#40289)"; exit 1; }
+    || { echo "ERROR: vllm/platforms/rocm.py does not detect the aiter ViT kernels."; \
+         echo "       Requires vLLM > v0.26.0."; exit 1; }
 
 # Triton kernel cache lives here (TRITON_CACHE_DIR below). On FIRST serve of a model, Triton
 # autotunes the GDN + ViT flash-attn kernels on the live GPU (a few minutes) and writes them


### PR DESCRIPTION
Removes the local build-time patch of `flash_attn_triton_available()` in `vllm/platforms/rocm.py` — the fix is now upstream.

### Why

vLLM PR [#40289](https://github.com/vllm-project/vllm/pull/40289) — *"[ROCm][ViT] Detect Triton-AMD kernels at their new aiter location"* — was **merged 2026-07-31** (commit `4fdd3e0b`). `rocm.py` now checks both the legacy `flash_attn.flash_attn_triton_amd` path and `aiter.ops.triton._triton_kernels.flash_attn_triton_amd` natively, which is exactly what the patch was doing.

Net: **−34 lines**, one fewer divergence from upstream to carry.

### No rush — the current patch is already self-deactivating

This is housekeeping, not a fix. The patch as it stands checks whether the kernels are already detected at the correct location and **no-ops if they are**:

```python
if old in s:
    ...                       # apply the rewrite (vLLM <= v0.26.0)
elif "aiter.ops.triton._triton_kernels.flash_attn_triton_amd" in s:
    print("rocm.py already detects the aiter location; no patch needed")
```

So on any vLLM containing #40289 the block just prints that line and does nothing. Leaving it in place costs nothing functionally — it only carries dead code.

### When to merge

Any time **after a vLLM release > v0.26.0 exists**. The fix landed after v0.26.0 was tagged (2026-07-27), so it is not in the current release:

```
$ gh api repos/vllm-project/vllm/compare/v0.26.0...4fdd3e0b74ab
status: diverged        # the commit is NOT an ancestor of the v0.26.0 tag
```

Since `build-ubuntu-stable.yml` resolves the **latest stable tag**, merging before that release would make builds resolve v0.26.0, which still needs the patch. There is also no benefit to merging the moment a new release appears — pick it up whenever convenient.

### If merged too early, the failure is loud, not silent

The runtime fail-fast guard is unchanged and still greps the installed `rocm.py` for the aiter kernel path. Without the patch and without the upstream fix, the build stops with:

```
ERROR: vllm/platforms/rocm.py does not detect the aiter ViT kernels.
       Requires vLLM > v0.26.0.
```

That property matters: the original failure mode was **silent** — ViT fell back to Torch SDPA and OOM'd at ~256 GiB only once someone sent an image. The guard turns that into a build-time error, so this change cannot ship broken vision.

### Testing

- Upstream `main` carries the dual-location check (`rocm.py`, `_has_spec(...)` on both paths), i.e. the patch's behaviour is preserved.
- `v0.26.0` does not contain it (compare above).
- No functional change for builds of vLLM > v0.26.0 — the patch was already a no-op there.
- Not built end-to-end against a >v0.26.0 release, since none exists yet. Worth one vision smoke-test (any image prompt) on the first build after that release lands.
