### PR TITLE
Feature/infiniband transport: Add InfiniBand transport option to cluster launcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -315,14 +315,21 @@ sudo reboot
 
 ## 7) Distributed Clustering (RDMA/RoCE)
 
-This toolbox supports clustering multiple Strix Halo nodes using Ethernet or RDMA/RoCE (for example, with an Intel E810). This enables **Tensor Parallelism** across machines.
+This toolbox supports clustering multiple Strix Halo nodes over **Ethernet**,
+**RDMA/RoCE** (for example, with an Intel E810), or **native InfiniBand** (with
+a dedicated IB HCA). This enables **Tensor Parallelism** across machines. The
+`start-vllm-cluster` launcher's **Select Transport** menu lets you pick the
+fabric per cluster start.
 
-**Detailed Documentation:** [RDMA Cluster Setup Guide](rdma_cluster/setup_guide.md)
+**Detailed Documentation:**
+*   [RDMA Cluster Setup Guide](rdma_cluster/setup_guide.md) — Ethernet and RDMA/RoCE (Intel E810).
+*   [InfiniBand Cluster Setup Guide](rdma_cluster/setup_guide_infiniband.md) — native InfiniBand (dedicated IB HCA).
 
 **Key Features:**
-*   **RCCL validation:** TP=2 has been tested over both Ethernet and RDMA/RoCE.
-*   **Easy Setup:** `refresh_toolbox.sh` automatically detects and exposes RDMA devices.
-*   **Cluster Management:** Included `start-vllm-cluster` TUI for managing Ray and vLLM.
+*   **RCCL validation:** TP=2 has been tested over Ethernet, RDMA/RoCE, and native InfiniBand.
+*   **Easy Setup:** `refresh_toolbox.sh` automatically detects and exposes RDMA/IB devices.
+*   **Cluster Management:** Included `start-vllm-cluster` TUI for managing Ray and vLLM, with a per-fabric transport selector (Auto / InfiniBand / RDMA-RoCE / Ethernet).
+*   **HCA pinning:** Set `VLLM_IB_HCA=<device>:<port>` (InfiniBand) or `VLLM_ROCE_HCA=<device>:<port>` (RoCE) to force a specific RDMA device; if several active RDMA ports exist the launcher warns and pins one so RCCL never sees an ambiguous HCA match.
 
 ## 8) AITER on Strix Halo Support Status
 

--- a/rdma_cluster/setup_guide.md
+++ b/rdma_cluster/setup_guide.md
@@ -2,6 +2,9 @@
 
 This guide details how to configure a two-node **AMD Strix Halo** cluster linked via **Intel E810 (RoCE v2)** for distributed vLLM inference using Tensor Parallelism.
 
+> **Native InfiniBand?** If you are running the cluster over a dedicated IB HCA
+> instead of RoCE, see the dedicated [InfiniBand Setup Guide](setup_guide_infiniband.md).
+
 ## Table of Contents
 
 1. [TL;DR (Quick Start)](#1-tldr-quick-start)
@@ -37,9 +40,18 @@ This guide details how to configure a two-node **AMD Strix Halo** cluster linked
 4.  **Run Cluster**:
     *   Run `start-vllm-cluster`.
     *   Select **"2. Start Ray Cluster"** (Follow prompts using the TUI).
+    *   When prompted, pick the **transport** — **`roce`** for the E810 (default
+        `auto` also works and falls back from InfiniBand to RoCE to Ethernet).
+        The choice is remembered for the subsequent vLLM launch.
     *   Select **"4. Launch VLLM Serve"** and choose your model. (Export `HF_TOKEN` first for gated models!)
 
 **Key Note**: The `refresh_toolbox.sh` script detects your Infiniband/RDMA devices and automatically configures the container to expose them.
+
+**HCA pinning**: To force a specific RDMA device instead of the auto-detected
+one, export `VLLM_IB_HCA=<device>:<port>` (native InfiniBand) or
+`VLLM_ROCE_HCA=<device>:<port>` (RoCE) before running `start-vllm-cluster`.
+If several active RDMA ports exist, the launcher prints a warning listing the
+candidates and the effective HCA.
 
 ---
 
@@ -283,6 +295,9 @@ A TUI utility, `start-vllm-cluster`, is provided to manage the Ray cluster and v
 4.  **Start Ray Cluster** (Option 2):
     *   **On Node 1**: Select **"Head"** when prompted.
     *   **On Node 2**: Select **"Worker"** when prompted.
+    *   Select a **transport** — `roce` (E810), `infiniband`, `ethernet`, or
+        `auto` (InfiniBand → RoCE → Ethernet). The choice is applied to the
+        Ray head/worker NCCL env and remembered for the vLLM launch.
     *   The script effectively runs:
         ```bash
         # Head

--- a/rdma_cluster/setup_guide_infiniband.md
+++ b/rdma_cluster/setup_guide_infiniband.md
@@ -20,7 +20,7 @@ routed Ethernet network entirely.
 > native-IB HCA on both nodes. The transport wiring below is the validated
 > configuration for this cluster setup.
 >
-> Refer to the the community wiki for details of a low budget infiniband hardware setup:
+> Refer to the the Strix Halo community wiki for details of a low budget infiniband hardware setup with Oculink:
 > <https://strixhalo.wiki/AI/Clustering_with_RDMA>
 
 ## Table of Contents
@@ -39,9 +39,9 @@ routed Ethernet network entirely.
 *   **Nodes**: 2x Strix Halo hosts (see the [main setup guide](setup_guide.md) for
     the base host/kernel/BIOS configuration).
 *   **HCAs**: one InfiniBand HCA per node. Both ports must be up and cabled
-    together, or plugged into an IB switch.
+    together. Use a DAC, a direct copper cable connection to get the lowest latency. 
 *   **Subnet Manager (opensm)**: native IB has **no self-managed fabric** — one
-    node (typically the head, here `fuzzy`) must run an InfiniBand Subnet Manager
+    node (typically the head) must run an InfiniBand Subnet Manager
     (`opensm`). Without it the ports will not reach `ACTIVE` state.
 *   **Control plane**: Ray / GLOO rendezvous and the management interface still
     run over Ethernet (the interface carrying `head_ip`/`worker_ip`). Only the

--- a/rdma_cluster/setup_guide_infiniband.md
+++ b/rdma_cluster/setup_guide_infiniband.md
@@ -1,0 +1,185 @@
+# AMD Strix Halo InfiniBand Cluster Setup Guide
+
+This guide covers running the two-node **Strix Halo** vLLM cluster over a **native
+InfiniBand** fabric, as an alternative to the [Ethernet / RDMA-RoCE guide](setup_guide.md).
+
+The toolbox container already ships everything needed on the data path
+(`rdma-core`, the libibverbs providers, `infiniband-diags`, `perftest`), and
+`refresh_toolbox.sh` exposes `/dev/infiniband` into the container when it detects
+an IB link, so no container changes are required. This guide covers the host-side
+fabric and how to select the **InfiniBand** transport in the cluster launcher.
+
+## When to use this guide
+
+Use native InfiniBand when you have a dedicated IB **HCA** (Host Channel
+Adapter — the network card that speaks InfiniBand) on both nodes. Compared to
+RoCE over a converged Ethernet NIC, native IB keeps the RDMA data path off the
+routed Ethernet network entirely.
+
+> Reference implementation: RCCL runs the TP all-reduce over the fabric with a
+> native-IB HCA on both nodes. The transport wiring below is the validated
+> configuration for this cluster setup.
+>
+> Refer to the the community wiki for details of a low budget infiniband hardware setup:
+> <https://strixhalo.wiki/AI/Clustering_with_RDMA>
+
+## Table of Contents
+
+1. [Fabric requirements](#1-fabric-requirements)
+2. [Host configuration](#2-host-configuration)
+3. [Verify the fabric from the host](#3-verify-the-fabric-from-the-host)
+4. [Selecting the InfiniBand transport](#4-selecting-the-infiniband-transport)
+5. [What the launcher sets (and why)](#5-what-the-launcher-sets-and-why)
+6. [Troubleshooting](#6-troubleshooting)
+
+---
+
+## 1. Fabric requirements
+
+*   **Nodes**: 2x Strix Halo hosts (see the [main setup guide](setup_guide.md) for
+    the base host/kernel/BIOS configuration).
+*   **HCAs**: one InfiniBand HCA per node. Both ports must be up and cabled
+    together, or plugged into an IB switch.
+*   **Subnet Manager (opensm)**: native IB has **no self-managed fabric** — one
+    node (typically the head, here `fuzzy`) must run an InfiniBand Subnet Manager
+    (`opensm`). Without it the ports will not reach `ACTIVE` state.
+*   **Control plane**: Ray / GLOO rendezvous and the management interface still
+    run over Ethernet (the interface carrying `head_ip`/`worker_ip`). Only the
+    RCCL data plane runs over the IB fabric.
+
+## 2. Host configuration
+
+These steps run on the **host OS** (not inside the toolbox) of both nodes.
+
+### 2.1 Install userspace tools
+
+```bash
+sudo dnf install rdma-core libibverbs-utils perftest infiniband-diags
+```
+
+> The container image already carries these (plus the validated rdma-core v62
+> overlay), but the host needs them for `ibv_devinfo`, `ibstat`, and `opensm`.
+
+### 2.2 Run a Subnet Manager on one node
+
+On the **head** node (one node only), enable and start `opensm`:
+
+```bash
+sudo systemctl enable --now opensm
+sudo systemctl status opensm
+```
+
+On a single-cable direct-connect setup this brings both ports to `ACTIVE`. Do
+**not** run `opensm` on both nodes unless you configure a master/slave policy.
+
+### 2.3 Bring the IB link up (no IP required)
+
+Native IB needs no IP address for RCCL to use it. The ports just need to be
+`ACTIVE`. If the kernel did not enable the ports automatically:
+
+```bash
+sudo ibportstate -D 0 1 enable     # or via udev/ibft, see below
+```
+
+### 2.4 (Optional) Persistent HCA naming
+
+If you have several RDMA devices (e.g. USB4 soft-RDMA plus the native HCA),
+stock udev rules can rename RDMA devices at boot and race your setup. On the
+test rig the IB device was udev-named after its netdev (`ibp195s0`). Pin the
+name you want, or disable persistent naming for the IB device:
+
+```bash
+# Example: keep the kernel's deterministic per-rail name
+sudo touch /etc/udev/rules.d/60-rdma-persistent-naming.rules.d/99-keep-native-ib.conf
+```
+
+An empty override of `60-rdma-persistent-naming.rules` achieves the same in
+other setups — keep the name you pin stable across reboots.
+
+## 3. Verify the fabric from the host
+
+```bash
+ibv_devinfo | grep -E 'hca_id|state|port|active_speed|active_width'
+ibstat
+rdma link
+```
+
+Both nodes should show the HCA port as `ACTIVE`, `LINK_UP`, with `active_speed:
+40 Gb/s` (or the negotiated rate). Then confirm the container can see the HCA —
+the `refresh_toolbox.sh` script does this automatically, but you can check with:
+
+```bash
+ls /dev/infiniband
+```
+
+## 4. Selecting the InfiniBand transport
+
+1.  Enter the toolbox and run the cluster manager:
+    ```bash
+    start-vllm-cluster
+    ```
+2.  Configure the Head/Worker IPs (the **Ethernet** management IPs — Ray and
+    GLOO rendezvous, not the IB fabric).
+3.  Select **"Start Ray Cluster"**, then **"Select Transport"** and choose
+    **`infiniband`** (or leave **`auto`** — it detects an active native-IB HCA
+    and selects InfiniBand automatically; otherwise it falls back to RDMA/RoCE,
+    then Ethernet).
+4.  Start the cluster as usual; both the Ray head/worker setup **and** the
+    subsequent vLLM launch read the same choice.
+
+## 5. What the launcher sets (and why)
+
+For `infiniband`, `scripts/cluster_manager.py` exports:
+
+| Variable | Value | Why |
+| :--- | :--- | :--- |
+| `NCCL_IB_DISABLE` | `0` | Enable the RDMA data path. |
+| `NCCL_IB_HCA` | one detected `<device>:<port>` | Pin a **single** HCA. An ambiguous prefix matching several ports makes RCCL's `ncclCommInitRank` fail with *"internal error"*. |
+| `NCCL_IB_GID_INDEX` | `0` | Native IB uses the **link-local GID**. Index `1` is RoCEv2-IPv4-only and does not exist on an IB fabric. |
+| `NCCL_PROTO` | `LL` | Low-latency protocol for the latency-bound decode all-reduce. |
+| `NCCL_ALGO` | `Ring` | Matches the validated TP=2 profile. |
+| `NCCL_IB_TIMEOUT` / `NCCL_IB_RETRY_CNT` | `23` / `7` | Fabric stability on the IB link. |
+| `NCCL_NET_GDR_LEVEL` | `0` | gfx1151 has no GPUDirect — RCCL host-stages the prefill all-reduce. Expected, not a fault. |
+| `NCCL_SOCKET_IFNAME` / `GLOO_SOCKET_IFNAME` | management iface | Control-plane sockets stay on Ethernet; only the data plane uses IB. |
+
+The HCA is detected per-node inside the generated setup script (first active
+`/sys/class/infiniband/*/ports/*/state`), so device names never have to match
+across hosts. To force a specific device, set **`VLLM_IB_HCA=<device>:<port>`**
+in the environment before starting the cluster — it wins over detection for
+both the setup scripts and the vLLM launch.
+
+When several active RDMA ports exist, the launcher prints a warning listing all
+candidates plus the effective HCA, so a silently-picked rail is always visible
+(set `VLLM_IB_HCA` to choose another).
+
+## 6. Troubleshooting
+
+### `ncclCommInitRank` fails with "internal error"
+RCCL could not resolve `NCCL_IB_HCA` to exactly one device. The launcher pins one
+port, but if you have multiple HCAs and overrode `NCCL_IB_HCA` manually, narrow it
+to a single `<device>:<port>`.
+
+### Ports stuck at `INIT` / not `ACTIVE`
+No (or conflicting) Subnet Manager. Confirm `opensm` is running on exactly one
+node and both cables are seated.
+
+### Slow prefill all-reduce
+gfx1151 has no GPUDirect — large (>1 MiB) all-reduces are host-staged through
+`NCCL_NET_GDR_LEVEL=0`. This is expected; only decode's latency-bound small
+all-reduces see the full IB benefit.
+
+### RCCL logging
+To debug an init failure, temporarily enable logging (the launcher keeps it off
+to reduce journal noise):
+
+```bash
+export NCCL_DEBUG=WARN
+export NCCL_DEBUG_SUBSYS=INIT,NET
+```
+
+Expect the harmless *"GPU Direct RDMA not available for device 0"* line on
+gfx1151.
+
+---
+
+This setup was tested with ConnectX-3 (mlx4) InfiniBand adapters.

--- a/scripts/cluster_manager.py
+++ b/scripts/cluster_manager.py
@@ -298,7 +298,7 @@ def setup_worker_node(worker_ip, head_ip, toolbox_name):
     # Calculate Interface dynamically
     RDMA_IFACE=$(ip -o addr show to {subnet} | awk '{{print $2}}' | head -n1)
     
-    echo "\\n--- Ray Worker Environment ({worker_ip}) ---"
+    echo "\n--- Ray Worker Environment ({worker_ip}) ---"
     echo "transport={transport} ({transport_label})"
 
     export RAY_DISABLE_METRICS=1
@@ -362,7 +362,7 @@ def setup_head_node(head_ip):
     # Calculate Interface dynamically
     RDMA_IFACE=$(ip -o addr show to {subnet} | awk '{{print $2}}' | head -n1)
     
-    echo "\\n--- Ray Head Environment ({head_ip}) ---"
+    echo "\n--- Ray Head Environment ({head_ip}) ---"
     echo "transport={transport} ({transport_label})"
 
     export RAY_DISABLE_METRICS=1

--- a/scripts/cluster_manager.py
+++ b/scripts/cluster_manager.py
@@ -2,6 +2,231 @@ import subprocess
 import time
 import os
 
+# Transport choices for the two-host RCCL cluster. "auto" resolves at runtime
+# in order: native InfiniBand when an active IB-link-layer HCA is present, else
+# RDMA/RoCE when an active Ethernet-link-layer RDMA port exists, else plain
+# Ethernet. "ethernet" forces TCP sockets with the IB/RDMA data path disabled.
+TRANSPORTS = ("auto", "infiniband", "roce", "ethernet")
+
+TRANSPORT_LABELS = {
+    "auto": "Auto-detect (InfiniBand, else RDMA/RoCE, else Ethernet)",
+    "infiniband": "InfiniBand (native IB, GID index 0)",
+    "roce": "RDMA/RoCE (Ethernet-based RDMA, GID index 1)",
+    "ethernet": "Ethernet (TCP sockets, RDMA disabled)",
+}
+
+
+def active_rdma_ports():
+    """Return [(device:port, link_layer)] for every ACTIVE RDMA port.
+
+    link_layer is "InfiniBand" (native IB) or "Ethernet" (RoCE). Used both to
+    pick the transport in "auto" mode and to warn when several rails exist.
+    """
+    import glob
+
+    ports = []
+    for state_path in sorted(glob.glob("/sys/class/infiniband/*/ports/*/state")):
+        try:
+            with open(state_path, "r", encoding="utf-8") as fh:
+                state = fh.read().strip().upper()
+        except OSError:
+            continue
+        if "ACTIVE" not in state:
+            continue
+        parts = state_path.split("/")
+        # /sys/class/infiniband/<device>/ports/<port>/state
+        dev = parts[-4]
+        port = parts[-2]
+        link_path = f"/sys/class/infiniband/{dev}/ports/{port}/link_layer"
+        try:
+            with open(link_path, "r", encoding="utf-8") as fh:
+                actual = fh.read().strip()
+        except OSError:
+            actual = ""
+        ports.append((f"{dev}:{port}", actual))
+    return ports
+
+
+def _active_rdma_port(link_layer):
+    """Return '<device>:<port>' of the first ACTIVE port with the given
+    link-layer type ("InfiniBand" for native IB, "Ethernet" for RoCE), or None."""
+    for device_port, actual in active_rdma_ports():
+        if link_layer.lower() in actual.lower():
+            return device_port
+    return None
+
+
+def detect_ib_hca():
+    """Return '<device>:<port>' of an active native InfiniBand HCA, or None."""
+    return _active_rdma_port("InfiniBand")
+
+
+def detect_roce_hca():
+    """Return '<device>:<port>' of an active RoCE (Ethernet link-layer) RDMA
+    port, or None."""
+    return _active_rdma_port("Ethernet")
+
+
+def resolve_transport(transport=None):
+    """Resolve a transport choice (or the persisted one) to a concrete mode."""
+    transport = (
+        transport or os.getenv("VLLM_CLUSTER_TRANSPORT") or "auto"
+    ).strip().lower()
+    if transport in ("infiniband", "roce", "ethernet"):
+        return transport
+    # auto: prefer native InfiniBand, then RDMA/RoCE, then plain Ethernet
+    if detect_ib_hca():
+        return "infiniband"
+    if detect_roce_hca():
+        return "roce"
+    return "ethernet"
+
+
+def _transport_vars(transport, net_iface_expr, hca_expr):
+    """Return [(key, value)] export pairs. Values may be shell expressions."""
+    pairs = [
+        ("NCCL_SOCKET_IFNAME", net_iface_expr),
+        ("GLOO_SOCKET_IFNAME", net_iface_expr),
+        ("NCCL_IB_TIMEOUT", "23"),
+        ("NCCL_IB_RETRY_CNT", "7"),
+        ("NCCL_NET_GDR_LEVEL", "0"),
+    ]
+    if transport == "ethernet":
+        pairs.append(("NCCL_IB_DISABLE", "1"))
+        return pairs
+    pairs.append(("NCCL_IB_DISABLE", "0"))
+    if transport == "infiniband":
+        if hca_expr:
+            pairs.append(("NCCL_IB_HCA", hca_expr))
+        # Native IB uses the link-local GID (index 0); index 1 is RoCEv2-IPv4
+        # only and does not exist on an IB fabric.
+        pairs.append(("NCCL_IB_GID_INDEX", "0"))
+        pairs.append(("NCCL_PROTO", "LL"))
+        pairs.append(("NCCL_ALGO", "Ring"))
+    else:  # roce (RDMA/RoCE)
+        pairs.append(("NCCL_IB_GID_INDEX", "1"))
+        if hca_expr:
+            pairs.append(("NCCL_IB_HCA", hca_expr))
+    return pairs
+
+
+def transport_env(transport, net_iface):
+    """Return the canonical NCCL/RCCL env dict for in-process use (vllm launch).
+
+    HCA selection honors an explicit ``VLLM_IB_HCA`` / ``VLLM_ROCE_HCA``
+    override, falling back to auto-detection. For RoCE the HCA is only pinned
+    when it is ambiguous (several active RDMA rails) so single-NIC behavior is
+    unchanged.
+    """
+    transport = resolve_transport(transport)
+    hca = None
+    if transport == "infiniband":
+        hca = os.getenv("VLLM_IB_HCA") or detect_ib_hca()
+    elif transport == "roce":
+        hca = os.getenv("VLLM_ROCE_HCA")
+        if not hca and len(active_rdma_ports()) > 1:
+            # Multiple active rails: pin one so RCCL never sees a prefix that
+            # matches more than one device (ncclCommInitRank "internal error").
+            hca = detect_roce_hca()
+    return {
+        key: value
+        for key, value in _transport_vars(transport, net_iface, hca)
+        if value not in (None, "")
+    }
+
+
+def transport_script_exports(transport, net_iface_expr="$RDMA_IFACE"):
+    """Return bash 'export' lines for a generated node-setup script.
+
+    ``net_iface_expr`` defaults to the ``$RDMA_IFACE`` the script computes; for
+    InfiniBand (and ambiguous multi-rail RoCE) the HCA is detected inside the
+    script so per-node device names never have to match the head node's. An
+    explicit ``VLLM_IB_HCA`` / ``VLLM_ROCE_HCA`` override wins over detection.
+    """
+    transport = resolve_transport(transport)
+    if transport == "infiniband":
+        override = os.getenv("VLLM_IB_HCA")
+        hca_expr = (
+            override if override else "$( _detect_rdma_hca 'InfiniBand' || true )"
+        )
+    elif transport == "roce":
+        override = os.getenv("VLLM_ROCE_HCA")
+        if override:
+            hca_expr = override
+        elif len(active_rdma_ports()) > 1:
+            hca_expr = "$( _detect_rdma_hca 'Ethernet' || true )"
+        else:
+            hca_expr = None
+    else:
+        hca_expr = None
+    lines = []
+    for key, value in _transport_vars(transport, net_iface_expr, hca_expr):
+        if value in (None, ""):
+            continue
+        lines.append(f"export {key}={value}")
+    return "\n".join(lines)
+
+
+def _ib_hca_detect_snippet():
+    return r'''
+# Detect the first ACTIVE RDMA port of a given link layer ("InfiniBand" for
+# native IB, "Ethernet" for RoCE). Used by the infiniband / multi-rail roce
+# transports so per-node device names never have to match the head node's.
+_detect_rdma_hca() {
+    local _kind="${1:-InfiniBand}"
+    for _state in /sys/class/infiniband/*/ports/*/state; do
+        [ -r "$_state" ] || continue
+        grep -qi active "$_state" || continue
+        _dev="${_state%%/ports/*}"
+        _dev="${_dev##*/}"
+        _port="$(basename "$(dirname "$_state")")"
+        _ll="/sys/class/infiniband/${_dev}/ports/${_port}/link_layer"
+        if [ -r "$_ll" ] && grep -qi "$_kind" "$_ll"; then
+            echo "${_dev}:${_port}"
+            return 0
+        fi
+    done
+    return 1
+}
+'''
+
+
+def warn_multi_rdma(transport):
+    """Warn when several active RDMA ports exist so a silent pin is visible.
+
+    Emits the candidate list plus the effective pin for the transport, and how
+    to override it (``VLLM_IB_HCA`` / ``VLLM_ROCE_HCA``). No-op with <2 ports.
+    """
+    ports = active_rdma_ports()
+    if len(ports) < 2:
+        return
+    active = [dp for dp, _ in ports]
+    print(f"[cluster] {len(active)} active RDMA ports detected: {', '.join(active)}")
+    if transport == "infiniband":
+        hca = os.getenv("VLLM_IB_HCA") or detect_ib_hca()
+        print(
+            f"[cluster] InfiniBand transport will use HCA {hca}; "
+            "set VLLM_IB_HCA to override"
+        )
+    elif transport == "roce":
+        hca = os.getenv("VLLM_ROCE_HCA")
+        if hca:
+            print(f"[cluster] RDMA/RoCE transport will use HCA {hca} (from VLLM_ROCE_HCA)")
+        else:
+            print(
+                "[cluster] RDMA/RoCE transport pins the first active RoCE rail; "
+                "set VLLM_ROCE_HCA to choose another"
+            )
+
+
+def _transport_note(transport):
+    if transport == "ethernet":
+        return "Ethernet transport (NCCL_IB_DISABLE=1, TCP sockets)"
+    if transport == "infiniband":
+        return "InfiniBand transport (native IB, GID index 0)"
+    return "RDMA/RoCE transport (GID index 1)"
+
+
 def get_net_iface(ip_prefix=None):
     """
     Auto-detects the interface that serves the cluster network.
@@ -55,9 +280,9 @@ def stop_cluster(worker_ip=None, toolbox_name="vllm-therock-gfx1151"):
 
 def setup_worker_node(worker_ip, head_ip, toolbox_name):
     subnet = get_subnet_from_ip(worker_ip)
-    
-    # Read overrides from current env
-    nccl_disable_val = os.getenv("NCCL_IB_DISABLE", "0")
+    transport = resolve_transport()
+    transport_label = TRANSPORT_LABELS.get(transport, transport)
+    warn_multi_rdma(transport)
     nccl_debug_val = os.getenv("NCCL_DEBUG", "")
     
     script = f"""
@@ -68,24 +293,14 @@ def setup_worker_node(worker_ip, head_ip, toolbox_name):
     # RayExecutorV2 applies driver model variables with setdefault. Keep the
     # daemon model-neutral so the selected model can supply its own AITER policy.
     unset VLLM_ROCM_USE_AITER VLLM_ROCM_USE_AITER_LINEAR
-    
+
+{_ib_hca_detect_snippet()}
     # Calculate Interface dynamically
     RDMA_IFACE=$(ip -o addr show to {subnet} | awk '{{print $2}}' | head -n1)
     
     echo "\\n--- Ray Worker Environment ({worker_ip}) ---"
-    echo "export RAY_DISABLE_METRICS=1"
-    echo "export RAY_EXPERIMENTAL_NOSET_ROCR_VISIBLE_DEVICES=1"
-    echo "export RAY_memory_monitor_refresh_ms=0"
-    echo "unset VLLM_ROCM_USE_AITER VLLM_ROCM_USE_AITER_LINEAR"
-    echo "export TRITON_CACHE_DIR=$HOME/.cache/triton"
-    echo "export VLLM_HOST_IP={worker_ip}"
-    echo "export RDMA_IFACE=$RDMA_IFACE"
-    echo "export NCCL_SOCKET_IFNAME=$RDMA_IFACE"
-    echo "export GLOO_SOCKET_IFNAME=$RDMA_IFACE"
-    echo "export NCCL_IB_TIMEOUT=23"
-    echo "export NCCL_IB_RETRY_CNT=7"
-    echo "export NCCL_IB_DISABLE={nccl_disable_val}"
-    
+    echo "transport={transport} ({transport_label})"
+
     export RAY_DISABLE_METRICS=1
     export RAY_EXPERIMENTAL_NOSET_ROCR_VISIBLE_DEVICES=1
     export RAY_memory_monitor_refresh_ms=0
@@ -93,12 +308,7 @@ def setup_worker_node(worker_ip, head_ip, toolbox_name):
     mkdir -p "$TRITON_CACHE_DIR"
     export VLLM_HOST_IP={worker_ip}
     export RDMA_IFACE=$RDMA_IFACE
-    export NCCL_SOCKET_IFNAME=$RDMA_IFACE
-    export GLOO_SOCKET_IFNAME=$RDMA_IFACE
-    # Stability for RDMA
-    export NCCL_IB_TIMEOUT=23
-    export NCCL_IB_RETRY_CNT=7
-    export NCCL_IB_DISABLE={nccl_disable_val}
+{transport_script_exports(transport)}
     """
     if nccl_debug_val:
         script += f"""
@@ -110,9 +320,7 @@ def setup_worker_node(worker_ip, head_ip, toolbox_name):
     
     script += f"""
     echo "\\nStarting Ray Worker on {worker_ip} connecting to {head_ip}..."
-    if [ "{nccl_disable_val}" = "1" ]; then
-        echo "Note: Worker is configured with NCCL_IB_DISABLE=1 (Ethernet Forced)"
-    fi
+    echo "Note: {_transport_note(transport)}"
     ray start --address='{head_ip}:6379' --num-gpus=1 --num-cpus=8 --disable-usage-stats
     """
     
@@ -134,11 +342,12 @@ def setup_worker_node(worker_ip, head_ip, toolbox_name):
 
 def setup_head_node(head_ip):
     subnet = get_subnet_from_ip(head_ip)
-    
+    transport = resolve_transport()
+    transport_label = TRANSPORT_LABELS.get(transport, transport)
+    warn_multi_rdma(transport)
+
     print(f"Setting up Head Node ({head_ip})...")
     
-    # Read overrides from current env
-    nccl_disable_val = os.getenv("NCCL_IB_DISABLE", "0")
     nccl_debug_val = os.getenv("NCCL_DEBUG", "")
     
     script = f"""
@@ -148,23 +357,13 @@ def setup_head_node(head_ip):
     # RayExecutorV2 applies driver model variables with setdefault. Keep the
     # daemon model-neutral so the selected model can supply its own AITER policy.
     unset VLLM_ROCM_USE_AITER VLLM_ROCM_USE_AITER_LINEAR
-    
+
+{_ib_hca_detect_snippet()}
     # Calculate Interface dynamically
     RDMA_IFACE=$(ip -o addr show to {subnet} | awk '{{print $2}}' | head -n1)
     
     echo "\\n--- Ray Head Environment ({head_ip}) ---"
-    echo "export RAY_DISABLE_METRICS=1"
-    echo "export RAY_EXPERIMENTAL_NOSET_ROCR_VISIBLE_DEVICES=1"
-    echo "export RAY_memory_monitor_refresh_ms=0"
-    echo "unset VLLM_ROCM_USE_AITER VLLM_ROCM_USE_AITER_LINEAR"
-    echo "export TRITON_CACHE_DIR=$HOME/.cache/triton"
-    echo "export VLLM_HOST_IP={head_ip}"
-    echo "export RDMA_IFACE=$RDMA_IFACE"
-    echo "export NCCL_SOCKET_IFNAME=$RDMA_IFACE"
-    echo "export GLOO_SOCKET_IFNAME=$RDMA_IFACE"
-    echo "export NCCL_IB_TIMEOUT=23"
-    echo "export NCCL_IB_RETRY_CNT=7"
-    echo "export NCCL_IB_DISABLE={nccl_disable_val}"
+    echo "transport={transport} ({transport_label})"
 
     export RAY_DISABLE_METRICS=1
     export RAY_EXPERIMENTAL_NOSET_ROCR_VISIBLE_DEVICES=1
@@ -173,12 +372,7 @@ def setup_head_node(head_ip):
     mkdir -p "$TRITON_CACHE_DIR"
     export VLLM_HOST_IP={head_ip}
     export RDMA_IFACE=$RDMA_IFACE
-    export NCCL_SOCKET_IFNAME=$RDMA_IFACE
-    export GLOO_SOCKET_IFNAME=$RDMA_IFACE
-    # Stability for RDMA
-    export NCCL_IB_TIMEOUT=23
-    export NCCL_IB_RETRY_CNT=7
-    export NCCL_IB_DISABLE={nccl_disable_val}
+{transport_script_exports(transport)}
     """
     
     if nccl_debug_val:
@@ -191,9 +385,7 @@ def setup_head_node(head_ip):
     
     script += f"""
     echo "\\nStarting Ray Head on {head_ip}..."
-    if [ "{nccl_disable_val}" = "1" ]; then
-        echo "Note: Head is configured with NCCL_IB_DISABLE=1 (Ethernet Forced)"
-    fi
+    echo "Note: {_transport_note(transport)}"
     ray start --head --port=6379 --node-ip-address={head_ip} --num-gpus=1 --num-cpus=8 --disable-usage-stats --include-dashboard=false
     """
     

--- a/scripts/start_vllm_cluster.py
+++ b/scripts/start_vllm_cluster.py
@@ -380,6 +380,9 @@ def configure_and_launch_vllm(model_idx, head_ip, remote_toolbox):
     # matches the Ray head/worker setup done under the same choice.
     transport = cluster_manager.resolve_transport()
     cluster_manager.warn_multi_rdma(transport)
+    # VLLM_CLUSTER_TRANSPORT is a launcher-only variable; drop it from the vLLM
+    # process env so vLLM's env whitelist does not flag it as unknown.
+    env.pop("VLLM_CLUSTER_TRANSPORT", None)
     transport_env = cluster_manager.transport_env(transport, rdma_iface)
     for key in (
         "NCCL_SOCKET_IFNAME",

--- a/scripts/start_vllm_cluster.py
+++ b/scripts/start_vllm_cluster.py
@@ -6,6 +6,7 @@ import shutil
 import tempfile
 import subprocess
 import time
+import inspect
 from pathlib import Path
 
 # Add benchmarks dir to path to import config
@@ -364,7 +365,13 @@ def configure_and_launch_vllm(model_idx, head_ip, remote_toolbox):
     env["TRITON_CACHE_DIR"] = str(get_triton_cache_dir())
     # Ray daemons start without model-specific AITER values. The driver supplies
     # explicit defaults here, with validated model policy applied last.
-    model_env = models.get_model_env(config, current_tp)
+    # get_model_env is tp-aware (env_by_tp) on some revisions of models.py and
+    # config-only on newer ones. Adapt to the signature present so the launcher
+    # works with whichever models.py ships in the container/image.
+    if len(inspect.signature(models.get_model_env).parameters) > 1:
+        model_env = models.get_model_env(config, current_tp)
+    else:
+        model_env = models.get_model_env(config)
     env.update(model_env)
     env["RAY_EXPERIMENTAL_NOSET_ROCR_VISIBLE_DEVICES"] = "1"
     env["VLLM_HOST_IP"] = head_ip

--- a/scripts/start_vllm_cluster.py
+++ b/scripts/start_vllm_cluster.py
@@ -368,9 +368,26 @@ def configure_and_launch_vllm(model_idx, head_ip, remote_toolbox):
     env.update(model_env)
     env["RAY_EXPERIMENTAL_NOSET_ROCR_VISIBLE_DEVICES"] = "1"
     env["VLLM_HOST_IP"] = head_ip
-    env["NCCL_SOCKET_IFNAME"] = rdma_iface
-    env["NCCL_IB_GID_INDEX"] = "1"
-    env["NCCL_NET_GDR_LEVEL"] = "0"
+
+    # Apply the cluster transport (ethernet / roce / infiniband) so the driver
+    # matches the Ray head/worker setup done under the same choice.
+    transport = cluster_manager.resolve_transport()
+    cluster_manager.warn_multi_rdma(transport)
+    transport_env = cluster_manager.transport_env(transport, rdma_iface)
+    for key in (
+        "NCCL_SOCKET_IFNAME",
+        "NCCL_IB_GID_INDEX",
+        "NCCL_IB_HCA",
+        "NCCL_IB_DISABLE",
+        "NCCL_IB_TIMEOUT",
+        "NCCL_IB_RETRY_CNT",
+        "NCCL_NET_GDR_LEVEL",
+        "NCCL_PROTO",
+        "NCCL_ALGO",
+        "GLOO_SOCKET_IFNAME",
+    ):
+        env.pop(key, None)
+    env.update(transport_env)
     
     cmd = [
         "vllm", "serve", model_id,
@@ -413,6 +430,7 @@ def configure_and_launch_vllm(model_idx, head_ip, remote_toolbox):
     print(f" Model:     {name}")
     print(f" Config:    TP={current_tp} | Seqs={current_seqs} | Ctx={current_ctx}")
     print(f" Backend:   {current_attn_backend}")
+    print(f" Transport: {transport} ({cluster_manager.TRANSPORT_LABELS.get(transport, transport)})")
     print(f" Speculate: {'native DSpark block' if use_speculative else 'disabled'}")
     print(f" Warmup:    {'automatic' if use_warmup else 'disabled'}")
     print(
@@ -426,12 +444,19 @@ def configure_and_launch_vllm(model_idx, head_ip, remote_toolbox):
         
     print("\n --- Environment Variables ---")
     vars_to_print = [
+        "VLLM_CLUSTER_TRANSPORT",
         "RAY_EXPERIMENTAL_NOSET_ROCR_VISIBLE_DEVICES",
         "TRITON_CACHE_DIR",
         "VLLM_HOST_IP",
         "NCCL_SOCKET_IFNAME",
         "NCCL_IB_GID_INDEX",
-        "NCCL_NET_GDR_LEVEL"
+        "NCCL_IB_HCA",
+        "NCCL_IB_DISABLE",
+        "NCCL_IB_TIMEOUT",
+        "NCCL_IB_RETRY_CNT",
+        "NCCL_NET_GDR_LEVEL",
+        "NCCL_PROTO",
+        "NCCL_ALGO"
     ]
     for key in model_env:
         if key not in vars_to_print:
@@ -526,29 +551,43 @@ def main():
                 head_ip, worker_ip = res
 
         elif choice == "3":
-            force_ethernet = False
             enable_nccl_debug = False
+            transport = os.getenv("VLLM_CLUSTER_TRANSPORT", "auto")
             
             while True:
-                eth_status = "YES" if force_ethernet else "NO"
                 debug_status = "YES" if enable_nccl_debug else "NO"
                 
                 c_choice = run_dialog([
                     "--clear", "--backtitle", "AMD VLLM RCCL Cluster Manager",
                     "--title", "Cluster Network Configuration",
-                    "--menu", f"Worker toolbox: {remote_toolbox}", "15", "72", "3",
-                    "1", f"Force Ethernet (Disable RDMA/RoCE):  {eth_status}",
+                    "--menu",
+                    f"Worker toolbox: {remote_toolbox}\n"
+                    f"Transport: {cluster_manager.TRANSPORT_LABELS.get(transport, transport)}",
+                    "15", "72", "3",
+                    "1", "Select Transport",
                     "2", f"Enable NCCL Debug Logging:           {debug_status}",
                     "3", "START CLUSTER"
                 ])
                 if not c_choice: break
                 
                 if c_choice == "1":
-                    force_ethernet = not force_ethernet
+                    transport_items = []
+                    for t in cluster_manager.TRANSPORTS:
+                        transport_items.extend([t, cluster_manager.TRANSPORT_LABELS[t]])
+                    sel = run_dialog([
+                        "--title", "Select Transport",
+                        "--default-item", transport,
+                        "--menu", "Choose the cluster fabric transport:",
+                        "14", "78", str(len(cluster_manager.TRANSPORTS)),
+                    ] + transport_items)
+                    if sel:
+                        transport = sel
                 elif c_choice == "2":
                     enable_nccl_debug = not enable_nccl_debug
                 elif c_choice == "3":
-                    os.environ["NCCL_IB_DISABLE"] = "1" if force_ethernet else "0"
+                    # Persisted across menu steps in this process; both the Ray
+                    # head/worker setup and the vllm launch read it.
+                    os.environ["VLLM_CLUSTER_TRANSPORT"] = transport
                     if enable_nccl_debug:
                         os.environ["NCCL_DEBUG"] = "INFO"
                         os.environ["NCCL_DEBUG_SUBSYS"] = "INIT,NET"
@@ -558,6 +597,7 @@ def main():
                     
                     subprocess.run(["clear"])
                     print("= Starting Ray Cluster Setup =")
+                    print(f"= Transport: {cluster_manager.TRANSPORT_LABELS.get(transport, transport)} =")
                     # 1. Start Head
                     if setup_head_node(head_ip):
                         print("Head node started successfully. Waiting 5s before worker connection...")

--- a/tests/test_cluster_environment.py
+++ b/tests/test_cluster_environment.py
@@ -1,6 +1,8 @@
+import io
 import sys
 import tempfile
 import unittest
+from contextlib import redirect_stdout
 from pathlib import Path
 from unittest.mock import patch
 
@@ -96,6 +98,158 @@ enabled = (
         script = run.call_args.kwargs["input"].decode()
         self.assertIn(AITER_UNSET, script)
         self.assertLess(script.index(AITER_UNSET), script.index("ray start --head"))
+
+    def test_auto_transport_resolves_to_roce_without_active_ib_hca(self):
+        with patch("cluster_manager.detect_ib_hca", return_value=None), patch(
+            "cluster_manager.detect_roce_hca", return_value="irdma0:1"
+        ):
+            self.assertEqual(cluster_manager.resolve_transport("auto"), "roce")
+
+    def test_auto_transport_resolves_to_ethernet_without_any_rdma(self):
+        with patch("cluster_manager.detect_ib_hca", return_value=None), patch(
+            "cluster_manager.detect_roce_hca", return_value=None
+        ):
+            self.assertEqual(cluster_manager.resolve_transport("auto"), "ethernet")
+
+    def test_auto_transport_resolves_to_infiniband_with_active_ib_hca(self):
+        with patch("cluster_manager.detect_ib_hca", return_value="mlx4_0:1"):
+            self.assertEqual(cluster_manager.resolve_transport("auto"), "infiniband")
+
+    def test_auto_transport_prefers_infiniband_over_roce(self):
+        with patch("cluster_manager.detect_ib_hca", return_value="mlx4_0:1"), patch(
+            "cluster_manager.detect_roce_hca", return_value="irdma0:1"
+        ):
+            self.assertEqual(cluster_manager.resolve_transport("auto"), "infiniband")
+
+    def test_transport_env_ethernet_disables_ib(self):
+        env = cluster_manager.transport_env("ethernet", "eth0")
+        self.assertEqual(env["NCCL_IB_DISABLE"], "1")
+        self.assertNotIn("NCCL_IB_HCA", env)
+        self.assertNotIn("NCCL_IB_GID_INDEX", env)
+        self.assertEqual(env["NCCL_SOCKET_IFNAME"], "eth0")
+        self.assertEqual(env["GLOO_SOCKET_IFNAME"], "eth0")
+
+    def test_transport_env_roce_uses_gid_index_one(self):
+        env = cluster_manager.transport_env("roce", "eth0")
+        self.assertEqual(env["NCCL_IB_DISABLE"], "0")
+        self.assertEqual(env["NCCL_IB_GID_INDEX"], "1")
+        self.assertNotIn("NCCL_PROTO", env)
+
+    def test_transport_env_infiniband_pins_hca_and_gid_zero(self):
+        with patch("cluster_manager.detect_ib_hca", return_value="mlx4_0:1"):
+            env = cluster_manager.transport_env("infiniband", "eth0")
+        self.assertEqual(env["NCCL_IB_DISABLE"], "0")
+        self.assertEqual(env["NCCL_IB_HCA"], "mlx4_0:1")
+        self.assertEqual(env["NCCL_IB_GID_INDEX"], "0")
+        self.assertEqual(env["NCCL_PROTO"], "LL")
+        self.assertEqual(env["NCCL_ALGO"], "Ring")
+
+    def test_transport_env_infiniband_honors_vllm_ib_hca_override(self):
+        with patch.dict("os.environ", {"VLLM_IB_HCA": "mlx5_0:1"}), patch(
+            "cluster_manager.detect_ib_hca", return_value="mlx4_0:1"
+        ):
+            env = cluster_manager.transport_env("infiniband", "eth0")
+        self.assertEqual(env["NCCL_IB_HCA"], "mlx5_0:1")
+
+    def test_transport_env_roce_honors_vllm_roce_hca_override(self):
+        with patch.dict("os.environ", {"VLLM_ROCE_HCA": "usb4_rdma0:1"}), patch(
+            "cluster_manager.active_rdma_ports",
+            return_value=[("irdma0:1", "Ethernet"), ("usb4_rdma0:1", "Ethernet")],
+        ), patch("cluster_manager.detect_roce_hca", return_value="irdma0:1"):
+            env = cluster_manager.transport_env("roce", "thunderbolt0")
+        self.assertEqual(env["NCCL_IB_HCA"], "usb4_rdma0:1")
+
+    def test_transport_env_roce_pins_hca_with_multiple_active_rails(self):
+        with patch(
+            "cluster_manager.active_rdma_ports",
+            return_value=[("irdma0:1", "Ethernet"), ("usb4_rdma0:1", "Ethernet")],
+        ), patch("cluster_manager.detect_roce_hca", return_value="irdma0:1"):
+            env = cluster_manager.transport_env("roce", "eth0")
+        self.assertEqual(env["NCCL_IB_HCA"], "irdma0:1")
+        self.assertEqual(env["NCCL_IB_GID_INDEX"], "1")
+
+    def test_transport_env_roce_leaves_hca_unset_with_single_rail(self):
+        with patch(
+            "cluster_manager.active_rdma_ports",
+            return_value=[("irdma0:1", "Ethernet")],
+        ):
+            env = cluster_manager.transport_env("roce", "eth0")
+        self.assertNotIn("NCCL_IB_HCA", env)
+        self.assertEqual(env["NCCL_IB_GID_INDEX"], "1")
+
+    def test_warn_multi_rdma_is_silent_with_less_than_two_ports(self):
+        captured = io.StringIO()
+        with patch(
+            "cluster_manager.active_rdma_ports", return_value=[("irdma0:1", "Ethernet")]
+        ), redirect_stdout(captured):
+            cluster_manager.warn_multi_rdma("roce")
+        self.assertEqual(captured.getvalue(), "")
+
+    def test_warn_multi_rdma_lists_candidates_and_effective_hca(self):
+        captured = io.StringIO()
+        with patch(
+            "cluster_manager.active_rdma_ports",
+            return_value=[
+                ("mlx4_0:1", "InfiniBand"),
+                ("irdma0:1", "Ethernet"),
+            ],
+        ), patch("cluster_manager.detect_ib_hca", return_value="mlx4_0:1"), patch.dict(
+            "os.environ", {}
+        ), redirect_stdout(captured):
+            cluster_manager.warn_multi_rdma("infiniband")
+        text = captured.getvalue()
+        self.assertIn("2 active RDMA ports detected", text)
+        self.assertIn("mlx4_0:1", text)
+        self.assertIn("irdma0:1", text)
+        self.assertIn("VLLM_IB_HCA", text)
+
+    def test_warn_multi_rdma_roce_mentions_vllm_roce_hca(self):
+        captured = io.StringIO()
+        with patch(
+            "cluster_manager.active_rdma_ports",
+            return_value=[("irdma0:1", "Ethernet"), ("usb4_rdma0:1", "Ethernet")],
+        ), redirect_stdout(captured):
+            cluster_manager.warn_multi_rdma("roce")
+        self.assertIn("VLLM_ROCE_HCA", captured.getvalue())
+
+    def test_transport_script_exports_reference_detect_helper_for_ib(self):
+        exports = cluster_manager.transport_script_exports("infiniband")
+        self.assertIn("export NCCL_IB_HCA=$(", exports)
+        self.assertIn("export NCCL_IB_GID_INDEX=0", exports)
+        self.assertIn("export NCCL_IB_DISABLE=0", exports)
+        self.assertIn("export NCCL_SOCKET_IFNAME=$RDMA_IFACE", exports)
+        exports_eth = cluster_manager.transport_script_exports("ethernet")
+        self.assertIn("export NCCL_IB_DISABLE=1", exports_eth)
+        self.assertNotIn("NCCL_IB_GID_INDEX", exports_eth)
+        self.assertNotIn("NCCL_IB_HCA", exports_eth)
+
+    def test_transport_script_exports_ib_honors_vllm_ib_hca_override(self):
+        with patch.dict("os.environ", {"VLLM_IB_HCA": "mlx5_0:1"}):
+            exports = cluster_manager.transport_script_exports("infiniband")
+        self.assertIn("export NCCL_IB_HCA=mlx5_0:1", exports)
+        self.assertNotIn("_detect_rdma_hca", exports)
+
+    def test_transport_script_exports_roce_pins_rail_when_multiple_active(self):
+        with patch(
+            "cluster_manager.active_rdma_ports",
+            return_value=[("irdma0:1", "Ethernet"), ("usb4_rdma0:1", "Ethernet")],
+        ):
+            exports = cluster_manager.transport_script_exports("roce")
+        self.assertIn("export NCCL_IB_HCA=$(", exports)
+        self.assertIn("_detect_rdma_hca 'Ethernet'", exports)
+
+    @patch("cluster_manager.subprocess.run")
+    def test_worker_ray_script_emits_selected_transport(self, run):
+        with patch.dict(
+            "os.environ", {"VLLM_CLUSTER_TRANSPORT": "infiniband"}
+        ), patch("cluster_manager.detect_ib_hca", return_value="mlx4_0:1"):
+            cluster_manager.setup_worker_node(
+                "192.168.100.2", "192.168.100.1", "vllm-therock-gfx1151-dev"
+            )
+        script = run.call_args.kwargs["input"].decode()
+        self.assertIn("transport=infiniband", script)
+        self.assertIn("export NCCL_IB_GID_INDEX=0", script)
+        self.assertIn("export NCCL_IB_DISABLE=0", script)
 
     @patch("cluster_manager.subprocess.run")
     def test_worker_ray_daemon_starts_without_aiter_policy(self, run):


### PR DESCRIPTION
Support native InfiniBand as a third fabric alongside Ethernet and RDMA/RoCE. 
Add an auto/infiniband/roce/ethernet transport menu in start-vllm-cluster, 
per-transport NCCL env generation with per-node HCA detection, and 
VLLM_IB_HCA / VLLM_ROCE_HCA overrides with a multi-rail warning. 
Document the InfiniBand setup and HCA pinning.

Adding support for RDMA via Thunderbolt to the scripts later shouldn't be difficult.

Let me know if you want me to run some benchmarks for my setup with PCIe 3.0 x4 ConnectX-3 mlx4 infiniband HCAs.