### PR TITLE
Shorten the shm-broadcast reader busy-loop default (1 s -> 2 ms)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -90,6 +90,12 @@ RUN if [ -n "$VLLM_COMMIT" ]; then \
 COPY scripts/patch_strix.py /opt/vllm/patch_strix.py
 RUN python /opt/vllm/patch_strix.py
 
+# Shorten the shm-broadcast reader busy-loop (busy_loop_s 1 s -> 2 ms): TP>=2
+# readers otherwise spin cores between decode steps, stealing SoC power and
+# thermal headroom from the GPU on Strix Halo. Fails closed if upstream moves.
+COPY scripts/patch_shm_spin.py /opt/vllm/patch_shm_spin.py
+RUN python /opt/vllm/patch_shm_spin.py
+
 # --- FP8 (W8A8) Strix Halo Triton kernels (EXPERIMENTAL / RFC — see issue #67) ---
 # Custom FP8 kernels by @leonyurko for gfx1151 (which has no native FP8). The kernel
 # modules live on PYTHONPATH (/opt/fp8); patch_fp8_kernels.py routes vLLM's

--- a/Dockerfile.ubuntu-repoamd
+++ b/Dockerfile.ubuntu-repoamd
@@ -128,12 +128,14 @@ RUN git clone https://github.com/vllm-project/vllm.git /opt/vllm && \
 WORKDIR /opt/vllm
 COPY scripts/patch_strix.py /opt/vllm/patch_strix.py
 COPY scripts/patch_dsv4_gfx1x.py /opt/vllm/patch_dsv4_gfx1x.py
+COPY scripts/patch_shm_spin.py /opt/vllm/patch_shm_spin.py
 COPY scripts/verify_vllm_compat.py /opt/vllm/verify_vllm_compat.py
 COPY scripts/patch_conch_moe_gfx1x.py /opt/patch_conch_moe_gfx1x.py
 COPY scripts/gfx1x_tilelang_mqa.py /opt/vllm/vllm/v1/attention/ops/gfx1x_tilelang_mqa.py
 COPY scripts/gfx1x_radix_topk.py /opt/vllm/vllm/v1/attention/ops/gfx1x_radix_topk.py
 COPY scripts/gfx1x_w8a8_bf16.py /opt/vllm/vllm/model_executor/kernels/linear/scaled_mm/gfx1x_w8a8_bf16.py
 RUN python /opt/vllm/patch_strix.py && \
+    python /opt/vllm/patch_shm_spin.py && \
     python /opt/vllm/verify_vllm_compat.py
 RUN python -m py_compile \
       /opt/vllm/vllm/v1/attention/ops/gfx1x_tilelang_mqa.py \
@@ -146,7 +148,9 @@ RUN python -m py_compile \
     && grep -q "PATCHED: gfx1x block-FP8 GEMM uses BF16 tl.dot" \
       /opt/vllm/vllm/model_executor/layers/quantization/utils/fp8_utils.py \
     && grep -q "PATCHED: gfx1x cached-BF16 W8A8 linear" \
-      /opt/vllm/vllm/model_executor/kernels/linear/scaled_mm/triton.py
+      /opt/vllm/vllm/model_executor/kernels/linear/scaled_mm/triton.py \
+    && grep -q "PATCHED: gfx1151 shm reader spin" \
+      /opt/vllm/vllm/distributed/device_communicators/shm_broadcast.py
 RUN grep -q "rocm_aiter_ops.refresh_env_variables()" \
       /opt/vllm/vllm/v1/executor/ray_executor_v2.py \
     && grep -q "refresh_gfx1x_w8a8_env()" \

--- a/docs/VLLM_PATCH_MANIFEST.md
+++ b/docs/VLLM_PATCH_MANIFEST.md
@@ -289,6 +289,18 @@ Comments inside `patch_strix.py` also record removed historical patches. Preserv
 those notes during upgrades: they prevent obsolete workarounds from being
 accidentally resurrected.
 
+## Shared-memory broadcast reader spin
+
+Owned by `scripts/patch_shm_spin.py`.
+
+| Upstream path | Local behavior | Update audit |
+|---|---|---|
+| `vllm/distributed/device_communicators/shm_broadcast.py` | Shortens `SpinCondition`'s reader-side `busy_loop_s` default from 1 s to 2 ms, so TP≥2 reader processes park in the event-driven zmq poller wait between decode steps instead of spinning cores for up to a second. CPU and GPU share one SoC power/thermal budget on Strix Halo; pinned cores steal frequency from inference. Reads within 2 ms still take the sched_yield fast path. Mirrors the runtime hotfix in the MiaAI-Lab DSpark two-node recipe (their issue #79). | Check whether upstream shortened the default, made the busy-loop window configurable (env or constructor plumbing), or replaced `SpinCondition`. Verify idle-core behavior on a TP=2 serve before removal. Still shipping at v0.27.1 (`busy_loop_s: float = 1`). |
+
+Build marker: `PATCHED: gfx1151 shm reader spin`.
+
+Tests: `tests/test_patch_shm_spin.py`.
+
 ## Non-vLLM build-time patches
 
 | Patcher/path | Local behavior | Update audit |

--- a/scripts/patch_shm_spin.py
+++ b/scripts/patch_shm_spin.py
@@ -1,0 +1,93 @@
+"""Shorten vLLM's shm-broadcast reader busy-loop default (busy_loop_s 1 s -> 2 ms).
+
+On TP>=2 serving, every process that reads the scheduler's shared-memory
+MessageQueue (EngineCore workers, API processes) busy-loops via sched_yield for
+up to ``busy_loop_s`` -- default 1 second -- after its last read, before
+falling back to the event-driven zmq poller wait:
+
+    class SpinCondition:
+        def __init__(..., busy_loop_s: float = 1):
+            ...
+        def wait(...):
+            if current_time <= self.last_read + self.busy_loop_s:
+                sched_yield()
+            else:
+                ... poller.poll(...) ...
+
+Decode-step IPC gaps are milliseconds, so under steady load the idle path
+never engages and N-1 cores burn at boost clocks between steps. On Strix Halo
+(gfx1151) the CPU and GPU share one SoC power/thermal budget, so those pinned
+cores directly steal frequency and thermal headroom from inference.
+
+Fix: lower the reader-side default from 1 s to 2 ms. Reads within 2 ms of the
+previous one still take the sched_yield fast path; anything slower parks in
+the zmq poller instead of spinning a core. The writer side hardcodes
+``busy_loop_s = 0`` and is unaffected. This mirrors the runtime hotfix shipped
+by the MiaAI-Lab DSpark two-node recipe (their issue #79).
+
+Upstream status: vllm-project/vllm v0.27.1 still defaults to 1 second.
+Delete this script once upstream shortens the default or makes the
+busy-loop window configurable.
+"""
+
+import sys
+from pathlib import Path
+
+MARKER = "PATCHED: gfx1151 shm reader spin"
+
+# SpinCondition's reader constructor default, verbatim in v0.27.1 and in the
+# June-2026 TheRock snapshots (8-space indent inside __init__).
+_ANCHOR = "        busy_loop_s: float = 1,"
+_REPLACEMENT = "        busy_loop_s: float = 0.002,  # " + MARKER
+
+
+def patch_file(path) -> bool:
+    """Patch shm_broadcast.py at `path`. Returns True when a change was made.
+
+    Idempotent: returns False without touching the file when MARKER is
+    already present. Fail-closed: raises SystemExit when the anchor is
+    missing, because a silent no-op would ship images with the spin intact.
+    """
+    path = Path(path)
+    txt = path.read_text()
+
+    if MARKER in txt:
+        print(" -> shm_broadcast.py already patched (idempotent no-op)")
+        return False
+
+    if _ANCHOR not in txt:
+        print(
+            " -> SpinCondition's 'busy_loop_s: float = 1' default not found; "
+            "the spin fix was NOT applied. If upstream shortened or made the "
+            "busy-loop configurable this script is obsolete -- verify and drop "
+            "it; otherwise update the anchor for the new shape.",
+            file=sys.stderr,
+        )
+        raise SystemExit(1)
+
+    path.write_text(txt.replace(_ANCHOR, _REPLACEMENT, 1))
+    print(
+        " -> Patched SpinCondition busy_loop_s 1 -> 0.002 "
+        "(readers park in the zmq poller after 2 ms instead of spinning 1 s)"
+    )
+    return True
+
+
+def main() -> int:
+    # In both image Dockerfiles this script runs from /opt/vllm, so the target
+    # is the source tree rooted beside it. An explicit argv override exists
+    # for offline testing against a fixture checkout.
+    default_target = (
+        Path(__file__).resolve().parent
+        / "vllm/distributed/device_communicators/shm_broadcast.py"
+    )
+    target = Path(sys.argv[1]) if len(sys.argv) > 1 else default_target
+    if not target.is_file():
+        print(f" -> {target} does not exist", file=sys.stderr)
+        return 1
+    patch_file(target)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_patch_shm_spin.py
+++ b/tests/test_patch_shm_spin.py
@@ -1,0 +1,93 @@
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "scripts"))
+
+import patch_shm_spin  # noqa: E402
+
+
+# Fixture mirrors the real SpinCondition constructor shape around the anchor
+# (v0.27.1 and TheRock snapshots), with enough surrounding context to catch
+# accidental whole-file rewrites.
+SPIN_CONDITION_SOURCE = '''\
+class SpinCondition:
+    """Spin quickly while reads are frequent, then idle on a zmq poller."""
+
+    def __init__(
+        self,
+        is_reader: bool,
+        context: zmq.Context,
+        notify_address: str,
+        busy_loop_s: float = 1,
+    ):
+        self.is_reader = is_reader
+
+        if is_reader:
+            # Time of last shm buffer read
+            self.last_read = time.monotonic()
+
+            # Time to keep busy-looping on the shm buffer before going idle
+            self.busy_loop_s = busy_loop_s
+            self.poller = zmq.Poller()
+        else:
+            self.last_read = 0
+            self.busy_loop_s = 0
+
+    def wait(self, timeout_ms=None):
+        current_time = time.monotonic()
+        if current_time <= self.last_read + self.busy_loop_s:
+            sched_yield()
+        else:
+            events = dict(self.poller.poll(timeout=timeout_ms))
+'''
+
+
+class ShmSpinPatchTests(unittest.TestCase):
+    def test_patch_shortens_reader_default_and_keeps_writer_side(self):
+        with tempfile.TemporaryDirectory() as td:
+            path = Path(td) / "shm_broadcast.py"
+            path.write_text(SPIN_CONDITION_SOURCE)
+
+            self.assertTrue(patch_shm_spin.patch_file(path))
+            patched = path.read_text()
+
+            self.assertIn(patch_shm_spin.MARKER, patched)
+            self.assertIn("busy_loop_s: float = 0.002", patched)
+            # Only the reader-side default changes.
+            self.assertNotIn("busy_loop_s: float = 1,", patched)
+            self.assertIn("self.busy_loop_s = 0\n", patched)
+            # Surrounding code is untouched.
+            self.assertIn("if current_time <= self.last_read + self.busy_loop_s:", patched)
+
+    def test_patch_is_idempotent(self):
+        with tempfile.TemporaryDirectory() as td:
+            path = Path(td) / "shm_broadcast.py"
+            path.write_text(SPIN_CONDITION_SOURCE)
+
+            self.assertTrue(patch_shm_spin.patch_file(path))
+            once = path.read_text()
+
+            self.assertFalse(patch_shm_spin.patch_file(path))
+            self.assertEqual(path.read_text(), once)
+
+    def test_patch_fails_closed_on_anchor_drift(self):
+        drifted = SPIN_CONDITION_SOURCE.replace(
+            "busy_loop_s: float = 1,", "busy_loop_s: float = 0.5,"
+        )
+        with tempfile.TemporaryDirectory() as td:
+            path = Path(td) / "shm_broadcast.py"
+            path.write_text(drifted)
+
+            with self.assertRaises(SystemExit) as ctx:
+                patch_shm_spin.patch_file(path)
+            self.assertEqual(ctx.exception.code, 1)
+            # Nothing was written.
+            self.assertEqual(path.read_text(), drifted)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Improvement snagged from https://github.com/MiaAI-Lab/DeepSeek-v4-Flash-DSpark-2x-DGX-Spark/commit/689ba323da8bf6afccb0f0669075cb6fbf233cd3

TP>=2 readers of the scheduler's shared-memory MessageQueue spin via sched_yield for up to SpinCondition.busy_loop_s (default 1 s) after their last read before parking in the zmq poller. Decode IPC gaps are milliseconds, so under load the idle path never engages and N-1 cores burn at boost clocks between steps; on Strix Halo those cores share one SoC power/thermal budget with the GPU.

New anchor-based patcher scripts/patch_shm_spin.py lowers the reader default to 2 ms in both image builds, wired into both Dockerfiles and the Ubuntu post-patch marker verification. Reads within 2 ms keep the sched_yield fast path; the writer side is untouched. Fails closed if the anchor moves (upstream may have shortened or made it configurable). Mirrors the runtime hotfix from the MiaAI-Lab DSpark recipe (#79); still shipping at vLLM v0.27.1.