### PR TITLE
Feature/recall acceptance probes

### DIFF
--- a/benchmarks/recall_probe.py
+++ b/benchmarks/recall_probe.py
@@ -1,12 +1,14 @@
 #!/usr/bin/env python3
 """RULER-style long-context recall probe for a live vLLM OpenAI endpoint.
 
-Synthetic needle-in-a-haystack style checks sized to an exact context target:
-the prompt filler is grown/corrected until /tokenize confirms at least
---min-token-frac (default 0.97) of the requested context length, so a
-"32k PASS" really means a ~32k prompt was sent. Complements the manifest's
-upgrade-procedure recall requirement (docs/VLLM_PATCH_MANIFEST.md) with
-something runnable against any host.
+Synthetic needle-in-a-haystack style checks sized to an exact context target.
+When the server exposes /tokenize, prompts are corrected before generation;
+otherwise (and additionally) the authoritative size comes from
+``usage.prompt_tokens`` on each completion, with one grow-and-resend round
+when a prompt lands under --min-token-frac (default 0.97) of the requested
+context length. A "32k PASS" therefore really means a ~32k prompt was billed.
+Complements the manifest's upgrade-procedure recall requirement
+(docs/VLLM_PATCH_MANIFEST.md) with something runnable against any host.
 
 Tasks:
   niah           one needle (magic number for a key) in neutral filler
@@ -31,6 +33,7 @@ Examples:
 import argparse
 import json
 import random
+import re
 import sys
 
 import requests
@@ -71,18 +74,58 @@ def _post(base_url, path, payload, api_key, request_timeout):
     )
 
 
+# vLLM serves /tokenize at the server root even when the OpenAI API sits
+# under /v1; older builds exposed neither path. Cache whichever URL answers.
+_TOKENIZE_URL = None
+
+
+def _tokenize_url_candidates(base_url):
+    base = base_url.rstrip("/")
+    root = re.sub(r"/v1/?$", "", base)
+    candidates = [base + "/tokenize", root + "/tokenize"]
+    if _TOKENIZE_URL:
+        candidates.insert(0, _TOKENIZE_URL)
+    seen, ordered = set(), []
+    for u in candidates:
+        if u not in seen:
+            seen.add(u)
+            ordered.append(u)
+    return ordered
+
+
 def count_tokens(base_url, model, api_key, request_timeout, text):
-    """Tokenize via the server so context claims are real, not estimated."""
-    try:
-        r = _post(
-            base_url, "/tokenize",
-            {"model": model, "messages": [{"role": "user", "content": text}]},
-            api_key, request_timeout,
-        )
-        r.raise_for_status()
-        return len(r.json()["tokens"])
-    except Exception:
-        return None
+    """Tokenize via the server so context claims are exact, not estimated.
+
+    Returns None when no tokenize endpoint answers; callers then fall back
+    to post-hoc sizing from usage.prompt_tokens.
+    """
+    global _TOKENIZE_URL
+    headers = {"Content-Type": "application/json"}
+    if api_key:
+        headers["Authorization"] = f"Bearer {api_key}"
+    for url in _tokenize_url_candidates(base_url):
+        try:
+            r = requests.post(
+                url,
+                json={"model": model,
+                      "messages": [{"role": "user", "content": text}]},
+                headers=headers,
+                timeout=request_timeout,
+            )
+            r.raise_for_status()
+        except Exception:
+            continue
+        _TOKENIZE_URL = url
+        body = r.json()
+        count = body.get("count")
+        if count is None:
+            count = len(body.get("tokens") or [])
+        return int(count)
+    return None
+
+
+def server_has_tokenize(base_url, model, api_key):
+    return count_tokens(base_url, model, api_key, 15, "ping") is not None
 
 
 def _stable_task_offset(name):
@@ -197,43 +240,85 @@ TASKS = {
 
 
 def run_one(base_url, model, api_key, request_timeout, max_tokens,
-            task_name, target_tokens, seed, min_frac, place_frac=0.5):
+            task_name, target_tokens, seed, min_frac, thinking,
+            use_tokenize, cal, place_frac=0.5):
     offset = _stable_task_offset(task_name)
     make, question, scorer = TASKS[task_name](seed + target_tokens + offset)
 
-    # Grow/correct the filler until /tokenize confirms the target window.
-    est_units = max(64, int(target_tokens * min_frac) // 32)
-    text, expected = make(place_frac, est_units)
-    full = f"{text}\n\nQuestion: {question}\nAnswer:"
-    tok = count_tokens(base_url, model, api_key, request_timeout, full)
+    def build(units):
+        text, expected = make(place_frac, units)
+        return (f"{text}\n\nQuestion: {question}\nAnswer:", expected)
 
-    tries = 0
-    while tok is not None and tries < 8:
-        if tok < target_tokens * min_frac:
-            est_units = int(est_units * (target_tokens * 0.99) / max(tok, 1)) + 8
-        elif tok > target_tokens * 1.03:
-            est_units = max(64, int(est_units * (target_tokens * 0.99) / tok))
-        else:
-            break
-        text, expected = make(place_frac, est_units)
-        full = f"{text}\n\nQuestion: {question}\nAnswer:"
-        tok = count_tokens(base_url, model, api_key, request_timeout, full)
-        tries += 1
-
-    row = {
-        "task": task_name,
-        "requested_context": target_tokens,
-        "tokenized_context": tok,
-    }
-    try:
-        r = _post(base_url, "/chat/completions", {
+    def send(full):
+        payload = {
             "model": model,
             "messages": [{"role": "user", "content": full}],
             "temperature": 0,
             "max_tokens": max_tokens,
-        }, api_key, request_timeout)
+        }
+        if not thinking:
+            # Reasoning would burn the token budget before the answer;
+            # recall probes want direct retrieval.
+            payload["chat_template_kwargs"] = {"thinking": False}
+        r = _post(base_url, "/chat/completions", payload,
+                  api_key, request_timeout)
         r.raise_for_status()
-        content = (r.json()["choices"][0]["message"]["content"] or "")
+        return r.json()
+
+    # Calibrated filler sizing: tokens per FILLER unit, learned from the
+    # first completion's usage and reused for every later row in this run.
+    if cal.get("tokens_per_unit"):
+        est_units = max(64, int(target_tokens * 0.99 / cal["tokens_per_unit"]))
+    else:
+        est_units = max(64, int(target_tokens * min_frac) // 32)
+    full, expected = build(est_units)
+
+    if use_tokenize:
+        # Correct the estimate before paying for a prefill.
+        tok = count_tokens(base_url, model, api_key, request_timeout, full)
+        tries = 0
+        while tok is not None and tries < 8:
+            cal["tokens_per_unit"] = max(tok, 1) / max(est_units, 1)
+            if tok < target_tokens * min_frac:
+                est_units = int(est_units * (target_tokens * 0.99) / max(tok, 1)) + 8
+            elif tok > target_tokens * 1.03:
+                est_units = max(64, int(est_units * (target_tokens * 0.99) / tok))
+            else:
+                break
+            full, expected = build(est_units)
+            tok = count_tokens(base_url, model, api_key, request_timeout, full)
+            tries += 1
+
+    row = {
+        "task": task_name,
+        "requested_context": target_tokens,
+    }
+
+    def absorb(body):
+        """Record usage + answer; returns prompt_tokens (0 if absent)."""
+        usage = body.get("usage") or {}
+        prompt_tokens = int(usage.get("prompt_tokens") or 0)
+        if prompt_tokens and est_units:
+            cal["tokens_per_unit"] = prompt_tokens / est_units
+        content = (body["choices"][0]["message"]["content"] or "")
+        return prompt_tokens, content
+
+    try:
+        body = send(full)
+        prompt_tokens, content = absorb(body)
+        resized = None
+        if prompt_tokens and not (min_frac * target_tokens
+                                  <= prompt_tokens <= target_tokens * 1.03):
+            # One corrective resend: grow when under target, shrink when over.
+            resized = "grow" if prompt_tokens < min_frac * target_tokens else "shrink"
+            est_units = max(
+                64, int(est_units * (target_tokens * 0.99) / prompt_tokens))
+            full, expected = build(est_units)
+            body = send(full)
+            prompt_tokens, content = absorb(body)
+        row["tokenized_context"] = prompt_tokens
+        if resized:
+            row["resized"] = resized
         row["response_excerpt"] = content[:200]
         if task_name == "cwe":
             found = scorer(content, expected)
@@ -246,12 +331,14 @@ def run_one(base_url, model, api_key, request_timeout, max_tokens,
             row["status"] = "PASS" if hit else "FAIL"
     except requests.exceptions.Timeout:
         row["status"] = "ERROR"
+        row["tokenized_context"] = None
         row["error"] = (
             f"client timeout after {request_timeout}s - raise "
             "--request-timeout; this is not scored as a model failure"
         )
     except Exception as exc:  # noqa: BLE001
         row["status"] = "ERROR"
+        row["tokenized_context"] = None
         row["error"] = f"{type(exc).__name__}: {exc}"[:300]
     return row
 
@@ -270,6 +357,9 @@ def main():
                    help="per-request client timeout in seconds")
     p.add_argument("--min-token-frac", type=float, default=0.97,
                    help="/tokenize must confirm at least this fraction")
+    p.add_argument("--thinking", action="store_true",
+                   help="leave the server's thinking mode enabled; default "
+                        "disables it per request so the budget reaches the answer")
     p.add_argument("--seed", type=int, default=1234)
     p.add_argument("--output", default=None, help="write the JSON report here")
     args = p.parse_args()
@@ -281,12 +371,19 @@ def main():
         model = r.json()["data"][0]["id"]
         print(f"discovered model: {model}")
 
+    use_tokenize = server_has_tokenize(args.base_url, model, args.api_key)
+    if not use_tokenize:
+        print("no /tokenize on this server; sizing verified post-hoc via "
+              "usage.prompt_tokens (one corrective resend when outside target)")
+
+    cal = {"tokens_per_unit": None}
     results = []
     for target in args.lengths:
         for task in args.tasks:
             row = run_one(args.base_url, model, args.api_key,
                           args.request_timeout, args.max_tokens,
-                          task, target, args.seed, args.min_token_frac)
+                          task, target, args.seed, args.min_token_frac,
+                          args.thinking, use_tokenize, cal)
             results.append(row)
             brief = row.get("response_excerpt") or row.get("error", "")
             extra = ""

--- a/benchmarks/recall_probe.py
+++ b/benchmarks/recall_probe.py
@@ -1,0 +1,315 @@
+#!/usr/bin/env python3
+"""RULER-style long-context recall probe for a live vLLM OpenAI endpoint.
+
+Synthetic needle-in-a-haystack style checks sized to an exact context target:
+the prompt filler is grown/corrected until /tokenize confirms at least
+--min-token-frac (default 0.97) of the requested context length, so a
+"32k PASS" really means a ~32k prompt was sent. Complements the manifest's
+upgrade-procedure recall requirement (docs/VLLM_PATCH_MANIFEST.md) with
+something runnable against any host.
+
+Tasks:
+  niah           one needle (magic number for a key) in neutral filler
+  niah_multikey  several keyed needles, only the queried one matters
+  vt             variable-tracking chain (VAR A = n; VAR B = A; ... )
+  cwe            common-words extraction: 10 planted words among noise
+
+Every task runs once per requested context length at a fixed needle placement
+(50%). Scoring is deterministic (temperature 0). The JSON report records the
+tokenized length actually sent; client-side timeouts are reported as ERROR
+with guidance rather than silently counted as model failures.
+
+Exit code: 0 when every task passes, 1 otherwise.
+
+Examples:
+  python3 benchmarks/recall_probe.py --base-url http://127.0.0.1:8000/v1 \
+      --lengths 8192 32768
+  python3 benchmarks/recall_probe.py --tasks niah vt --lengths 131072 \
+      --output results/recall.json
+"""
+
+import argparse
+import json
+import random
+import sys
+
+import requests
+
+FILLER = (
+    "The grass is green. The sky is blue. The sun is bright. The air is clean. "
+    "The road is long. The wind is calm. The lake is cold. The trees are tall. "
+)
+
+NEEDLE_FMT = "One of the special magic numbers for {key} is: {value}."
+NIAH_Q = (
+    "What is the special magic number for {key} mentioned in the provided text?"
+)
+
+VT_SEED_VALUES = [
+    "72513", "48290", "91034", "36572", "51847",
+    "80293", "24615", "63708", "97421", "15836",
+]
+
+# Deliberately disjoint from the filler vocabulary above.
+CWE_VOCAB = [
+    "stone", "cloud", "ember", "harbor", "meadow", "lantern",
+    "cinder", "orchid", "thistle", "anchor", "willow", "quartz", "fable",
+    "beacon",
+]
+CWE_PASS_MIN = 8
+
+
+def _post(base_url, path, payload, api_key, request_timeout):
+    headers = {"Content-Type": "application/json"}
+    if api_key:
+        headers["Authorization"] = f"Bearer {api_key}"
+    return requests.post(
+        base_url.rstrip("/") + path,
+        json=payload,
+        headers=headers,
+        timeout=request_timeout,
+    )
+
+
+def count_tokens(base_url, model, api_key, request_timeout, text):
+    """Tokenize via the server so context claims are real, not estimated."""
+    try:
+        r = _post(
+            base_url, "/tokenize",
+            {"model": model, "messages": [{"role": "user", "content": text}]},
+            api_key, request_timeout,
+        )
+        r.raise_for_status()
+        return len(r.json()["tokens"])
+    except Exception:
+        return None
+
+
+def _stable_task_offset(name):
+    # PYTHONHASHSEED-randomized hash() would make runs unreproducible.
+    return sum((i + 1) * ord(c) for i, c in enumerate(name)) % 100000
+
+
+def _filler(units):
+    return FILLER * max(0, int(units))
+
+
+class Tasks:
+    @staticmethod
+    def niah(seed):
+        rng = random.Random(seed)
+        key = f"word-{rng.randrange(10**6):06d}"
+        value = str(rng.randrange(10**7)).zfill(7)
+        needle = NEEDLE_FMT.format(key=key, value=value)
+
+        def make(place_frac, filler_units):
+            cut = filler_units * place_frac
+            return (
+                _filler(cut) + needle + _filler(filler_units - cut),
+                value,
+            )
+
+        question = NIAH_Q.format(key=key)
+        return make, question, lambda resp, exp: exp in resp
+
+    @staticmethod
+    def niah_multikey(seed):
+        rng = random.Random(seed)
+        wanted_idx = rng.randrange(4)
+        pairs = []
+        for i in range(4):
+            k = f"key-{rng.randrange(10**6):06d}"
+            v = str(rng.randrange(10**7)).zfill(7)
+            pairs.append((k, v))
+
+        def make(place_frac, filler_units):
+            per = filler_units // 4
+            chunks = []
+            for i, (k, v) in enumerate(pairs):
+                cut = per * place_frac
+                chunks.append(
+                    _filler(cut) + NEEDLE_FMT.format(key=k, value=v)
+                    + _filler(per - cut)
+                )
+            return "".join(chunks), pairs[wanted_idx][1]
+
+        question = NIAH_Q.format(key=pairs[wanted_idx][0])
+        return make, question, lambda resp, exp: exp in resp
+
+    @staticmethod
+    def vt(seed):
+        rng = random.Random(seed)
+        chain_len = 16
+        names = [f"VAR{i}" for i in range(chain_len)]
+        head_value = VT_SEED_VALUES[rng.randrange(len(VT_SEED_VALUES))]
+        block_lines = [f"VAR {names[0]} = {head_value}."]
+        block_lines += [f"VAR {n} = {p}." for p, n in zip(names, names[1:])]
+        block = "\n".join(block_lines)
+
+        def make(place_frac, filler_units):
+            cut = filler_units * place_frac
+            return (
+                _filler(cut) + "\n" + block + "\n" + _filler(filler_units - cut),
+                head_value,
+            )
+
+        question = (
+            f"Follow the variable assignments in the provided text and report "
+            f"the numeric value that {names[-1]} refers to."
+        )
+        return make, question, lambda resp, exp=head_value: exp in resp
+
+    @staticmethod
+    def cwe(seed):
+        rng = random.Random(seed)
+        words = rng.sample(CWE_VOCAB, 10)
+
+        def make(place_frac, filler_units):
+            gap = max(1, filler_units // (len(words) + 2))
+            pieces = []
+            idx = 0
+            for u in range(filler_units):
+                pieces.append(FILLER)
+                if idx < len(words) and u == gap * (idx + 1):
+                    pieces.append(f"The {words[idx]} remembers the old song. ")
+                    idx += 1
+            return "".join(pieces), words
+
+        question = (
+            "Ten uncommon words were deliberately placed throughout the "
+            "provided text, each followed by the phrase 'remembers the old "
+            "song'. List those ten words as a comma-separated list."
+        )
+
+        def score(resp, expected):
+            low = resp.lower()
+            return sum(1 for w in expected if w in low)
+
+        return make, question, score
+
+
+TASKS = {
+    "niah": Tasks.niah,
+    "niah_multikey": Tasks.niah_multikey,
+    "vt": Tasks.vt,
+    "cwe": Tasks.cwe,
+}
+
+
+def run_one(base_url, model, api_key, request_timeout, max_tokens,
+            task_name, target_tokens, seed, min_frac, place_frac=0.5):
+    offset = _stable_task_offset(task_name)
+    make, question, scorer = TASKS[task_name](seed + target_tokens + offset)
+
+    # Grow/correct the filler until /tokenize confirms the target window.
+    est_units = max(64, int(target_tokens * min_frac) // 32)
+    text, expected = make(place_frac, est_units)
+    full = f"{text}\n\nQuestion: {question}\nAnswer:"
+    tok = count_tokens(base_url, model, api_key, request_timeout, full)
+
+    tries = 0
+    while tok is not None and tries < 8:
+        if tok < target_tokens * min_frac:
+            est_units = int(est_units * (target_tokens * 0.99) / max(tok, 1)) + 8
+        elif tok > target_tokens * 1.03:
+            est_units = max(64, int(est_units * (target_tokens * 0.99) / tok))
+        else:
+            break
+        text, expected = make(place_frac, est_units)
+        full = f"{text}\n\nQuestion: {question}\nAnswer:"
+        tok = count_tokens(base_url, model, api_key, request_timeout, full)
+        tries += 1
+
+    row = {
+        "task": task_name,
+        "requested_context": target_tokens,
+        "tokenized_context": tok,
+    }
+    try:
+        r = _post(base_url, "/chat/completions", {
+            "model": model,
+            "messages": [{"role": "user", "content": full}],
+            "temperature": 0,
+            "max_tokens": max_tokens,
+        }, api_key, request_timeout)
+        r.raise_for_status()
+        content = (r.json()["choices"][0]["message"]["content"] or "")
+        row["response_excerpt"] = content[:200]
+        if task_name == "cwe":
+            found = scorer(content, expected)
+            row["found"] = found
+            row["of"] = len(expected)
+            row["status"] = "PASS" if found >= CWE_PASS_MIN else "FAIL"
+        else:
+            hit = scorer(content, expected)
+            row["expected"] = expected
+            row["status"] = "PASS" if hit else "FAIL"
+    except requests.exceptions.Timeout:
+        row["status"] = "ERROR"
+        row["error"] = (
+            f"client timeout after {request_timeout}s - raise "
+            "--request-timeout; this is not scored as a model failure"
+        )
+    except Exception as exc:  # noqa: BLE001
+        row["status"] = "ERROR"
+        row["error"] = f"{type(exc).__name__}: {exc}"[:300]
+    return row
+
+
+def main():
+    p = argparse.ArgumentParser(description="RULER-style long-context recall probe")
+    p.add_argument("--base-url", default="http://127.0.0.1:8000/v1")
+    p.add_argument("--model", default=None,
+                   help="served model id; defaults to first entry of /v1/models")
+    p.add_argument("--api-key", default=None)
+    p.add_argument("--tasks", nargs="+", default=list(TASKS), choices=sorted(TASKS))
+    p.add_argument("--lengths", nargs="+", type=int, default=[8192, 32768],
+                   help="context targets in tokens (must fit max_model_len)")
+    p.add_argument("--max-tokens", type=int, default=128)
+    p.add_argument("--request-timeout", type=float, default=900,
+                   help="per-request client timeout in seconds")
+    p.add_argument("--min-token-frac", type=float, default=0.97,
+                   help="/tokenize must confirm at least this fraction")
+    p.add_argument("--seed", type=int, default=1234)
+    p.add_argument("--output", default=None, help="write the JSON report here")
+    args = p.parse_args()
+
+    model = args.model
+    if not model:
+        r = requests.get(args.base_url.rstrip("/") + "/models", timeout=30)
+        r.raise_for_status()
+        model = r.json()["data"][0]["id"]
+        print(f"discovered model: {model}")
+
+    results = []
+    for target in args.lengths:
+        for task in args.tasks:
+            row = run_one(args.base_url, model, args.api_key,
+                          args.request_timeout, args.max_tokens,
+                          task, target, args.seed, args.min_token_frac)
+            results.append(row)
+            brief = row.get("response_excerpt") or row.get("error", "")
+            extra = ""
+            if task == "cwe" and "found" in row:
+                extra = f" found={row['found']}/{row['of']}"
+            print(f"[{row['status']:>5}] {task:>13} @{target:>8}: "
+                  f"tok={row['tokenized_context']}{extra} | {brief[:70]}")
+
+    ok = all(r["status"] == "PASS" for r in results)
+    report = {
+        "model": model,
+        "base_url": args.base_url,
+        "min_token_frac": args.min_token_frac,
+        "passed": ok,
+        "results": results,
+    }
+    if args.output:
+        with open(args.output, "w") as f:
+            json.dump(report, f, indent=2)
+        print(f"report: {args.output}")
+    print("RECALL PROBE:", "ALL PASS" if ok else "FAILURES PRESENT")
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/benchmarks/spec_acceptance.py
+++ b/benchmarks/spec_acceptance.py
@@ -37,10 +37,15 @@ SPEC_PREFIX = "vllm:spec_decode_"
 POS_RE = re.compile(r"_per_pos(\d+)$")
 
 
+def _metrics_url(base_url):
+    # /metrics is served at the server root even when the OpenAI API sits
+    # under /v1, so accept either form of --base-url.
+    return re.sub(r"/v1/?$", "", base_url.rstrip("/")) + "/metrics"
+
+
 def snapshot_spec_counters(base_url, api_key):
     headers = {"Authorization": f"Bearer {api_key}"} if api_key else {}
-    r = requests.get(base_url.rstrip("/") + "/metrics", headers=headers,
-                     timeout=30)
+    r = requests.get(_metrics_url(base_url), headers=headers, timeout=30)
     r.raise_for_status()
     totals = {}
     for line in r.text.splitlines():
@@ -78,7 +83,12 @@ def drive_burst(base_url, model, api_key, prompt, num_requests, concurrency,
                           json=payload, headers=headers,
                           timeout=request_timeout)
         r.raise_for_status()
-        return len(r.json()["choices"][0]["message"]["content"] or "")
+        body = r.json()
+        # Count billed completion tokens rather than visible content:
+        # reasoning-mode servers can return null content while still
+        # generating (and drafting) the full budget.
+        usage = body.get("usage") or {}
+        return int(usage.get("completion_tokens") or 0)
 
     with ThreadPoolExecutor(max_workers=max(1, concurrency)) as pool:
         outs = list(pool.map(one, range(num_requests)))
@@ -177,7 +187,7 @@ def main():
                            args.num_requests, args.concurrency,
                            args.max_tokens, args.request_timeout)
         print(f"burst complete: {len(lens)} requests, "
-              f"{sum(lens)} generated chars total")
+              f"{sum(lens)} completion tokens total")
 
         after = snapshot_spec_counters(args.base_url, args.api_key)
         report(before, after, args.output)

--- a/benchmarks/spec_acceptance.py
+++ b/benchmarks/spec_acceptance.py
@@ -1,0 +1,191 @@
+#!/usr/bin/env python3
+"""Speculative-decoding acceptance meter for a live vLLM OpenAI endpoint.
+
+Snapshots the Prometheus /metrics endpoint, drives a fixed burst of chat
+completions, snapshots again, and reports the delta of every
+``vllm:spec_decode_*`` counter -- overall accepted/draft ratio plus the
+per-position acceptance curve. This is the number every kernel or launch-policy
+change must hold steady against: a faster engine that quietly loses draft
+acceptance is a net loss.
+
+Counter semantics differ slightly across vLLM versions (some count the bonus
+token in drafts, some do not), so raw deltas are always printed alongside any
+derived ratio. Per-position counters only advance at position k when all
+earlier draft positions were accepted, so ``per_pos[k] / per_pos[1]``
+approximates P(at least k draft tokens accepted).
+
+Exit code: 0 normally, including when speculative decoding appears disabled
+(no spec_decode metrics found -- guidance printed). Exit 2 on transport errors.
+
+Example:
+  python3 benchmarks/spec_acceptance.py --base-url http://127.0.0.1:8000/v1 \
+      --num-requests 8 --concurrency 4 --output results/acceptance.json
+"""
+
+import argparse
+import json
+import re
+import sys
+from concurrent.futures import ThreadPoolExecutor
+
+import requests
+
+COUNTER_RE = re.compile(
+    r"^([a-zA-Z_:][a-zA-Z0-9_:]*)(\{[^}]*\})?\s+([-+eE0-9.]+)\s*$"
+)
+SPEC_PREFIX = "vllm:spec_decode_"
+POS_RE = re.compile(r"_per_pos(\d+)$")
+
+
+def snapshot_spec_counters(base_url, api_key):
+    headers = {"Authorization": f"Bearer {api_key}"} if api_key else {}
+    r = requests.get(base_url.rstrip("/") + "/metrics", headers=headers,
+                     timeout=30)
+    r.raise_for_status()
+    totals = {}
+    for line in r.text.splitlines():
+        if line.startswith("#"):
+            continue
+        m = COUNTER_RE.match(line.strip())
+        if not m:
+            continue
+        name, _, value = m.group(1), m.group(2), m.group(3)
+        if not name.startswith(SPEC_PREFIX):
+            continue
+        try:
+            v = float(value)
+        except ValueError:
+            continue
+        # Aggregate across label sets (e.g. per-model labels).
+        totals[name] = totals.get(name, 0.0) + v
+    return totals
+
+
+def drive_burst(base_url, model, api_key, prompt, num_requests, concurrency,
+                max_tokens, request_timeout):
+    headers = {"Content-Type": "application/json"}
+    if api_key:
+        headers["Authorization"] = f"Bearer {api_key}"
+
+    def one(i):
+        payload = {
+            "model": model,
+            "messages": [{"role": "user", "content": f"{prompt}\n(variation {i})"}],
+            "temperature": 0.7,
+            "max_tokens": max_tokens,
+        }
+        r = requests.post(base_url.rstrip("/") + "/chat/completions",
+                          json=payload, headers=headers,
+                          timeout=request_timeout)
+        r.raise_for_status()
+        return len(r.json()["choices"][0]["message"]["content"] or "")
+
+    with ThreadPoolExecutor(max_workers=max(1, concurrency)) as pool:
+        outs = list(pool.map(one, range(num_requests)))
+    return outs
+
+
+def fmt(n):
+    return f"{n:.0f}"
+
+
+def report(before, after, output_path):
+    keys = sorted(set(before) | set(after))
+    deltas = {k: after.get(k, 0.0) - before.get(k, 0.0) for k in keys}
+    changed = {k: v for k, v in deltas.items() if abs(v) > 0}
+
+    print("\n-- spec_decode counter deltas over the measurement window --")
+    for k in sorted(changed):
+        print(f"{k[len(SPEC_PREFIX):]:<44} {fmt(changed[k]):>12}")
+
+    pos = {}
+    other = {}
+    for k, v in changed.items():
+        base = k[len(SPEC_PREFIX):]
+        m = POS_RE.search(base)
+        if m:
+            pos[int(m.group(1))] = v
+        else:
+            other[base] = v
+
+    drafts = next((v for n, v in other.items() if "draft_tokens" in n), None)
+    accepted = next((v for n, v in other.items() if "accepted_tokens" in n
+                     and "per_pos" not in n), None)
+
+    if not changed:
+        print("no spec_decode counters moved during the burst; either "
+              "speculative decoding is off, the burst was too small "
+              "(raise --num-requests/--max-tokens), or metrics are stale")
+    elif drafts is None and accepted is None and not pos:
+        print("spec_decode counters present but no recognized "
+              "draft/accepted tokens counters; inspect the deltas above")
+
+    if drafts and accepted is not None and drafts > 0:
+        print(f"\noverall accepted/draft = {accepted / drafts:.4f} "
+              f"({fmt(accepted)} / {fmt(drafts)}; ratio includes any "
+              f"version-specific bonus-token accounting)")
+    if pos:
+        first = pos.get(1, 0.0)
+        print("\ndraft-position acceptance curve (pos k reached only if "
+              "positions < k were accepted):")
+        for k in sorted(pos):
+            rel = f"{pos[k] / first:6.3f}" if first else "   n/a"
+            print(f"  pos {k}: {fmt(pos[k]):>10}   rel_to_pos1={rel}")
+
+    if output_path:
+        doc = {"deltas": changed, "draft_tokens": drafts,
+               "accepted_tokens": accepted, "per_position": pos}
+        with open(output_path, "w") as f:
+            json.dump(doc, f, indent=2)
+        print(f"\nreport: {output_path}")
+
+
+def main():
+    p = argparse.ArgumentParser(description="speculative-decode acceptance meter")
+    p.add_argument("--base-url", default="http://127.0.0.1:8000/v1")
+    p.add_argument("--model", default=None,
+                   help="served model id; defaults to first entry of /v1/models")
+    p.add_argument("--api-key", default=None)
+    p.add_argument("--prompt", default=(
+        "Write a detailed step-by-step recipe for baking sourdough bread, "
+        "including timings, temperatures, and common failure modes."))
+    p.add_argument("--num-requests", type=int, default=8)
+    p.add_argument("--concurrency", type=int, default=4)
+    p.add_argument("--max-tokens", type=int, default=256,
+                   help="generation cap; keep high enough that drafting has room")
+    p.add_argument("--request-timeout", type=float, default=600)
+    p.add_argument("--output", default=None, help="write the JSON report here")
+    args = p.parse_args()
+
+    try:
+        before = snapshot_spec_counters(args.base_url, args.api_key)
+        if not before:
+            print("no vllm:spec_decode_* metrics found on this server.")
+            print("If you expected speculative decoding here, check that the ")
+            print("server was launched with a --speculative-config and that ")
+            print("/metrics exposes spec-decode counters on this version.")
+            return 0
+
+        model = args.model
+        if not model:
+            r = requests.get(args.base_url.rstrip("/") + "/models", timeout=30)
+            r.raise_for_status()
+            model = r.json()["data"][0]["id"]
+            print(f"discovered model: {model}")
+
+        lens = drive_burst(args.base_url, model, args.api_key, args.prompt,
+                           args.num_requests, args.concurrency,
+                           args.max_tokens, args.request_timeout)
+        print(f"burst complete: {len(lens)} requests, "
+              f"{sum(lens)} generated chars total")
+
+        after = snapshot_spec_counters(args.base_url, args.api_key)
+        report(before, after, args.output)
+        return 0
+    except requests.exceptions.RequestException as exc:
+        print(f"ERROR talking to {args.base_url}: {exc}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Add recall probe and spec-decode acceptance meters

## Why this is needed

This repo ships aggressive local patches. Today the only live check most of them get is "does the server come up and answer coherently" — which cannot catch the two failure modes that actually matter for this stack, because both are *silent*: output stays fluent, tokens keep flowing, and every per-request smoke test passes.

**1. Long-context recall can quietly break.** DeepSeek V4-Flash serves up to ~512K-token contexts through a sparse indexer and several patched cache paths. A subtle layout, quantization, or kernel change can corrupt what the model retrieves from deep in the prompt while the prose stays perfectly readable — the model simply answers from partial context or invents plausibly. Nothing in a normal chat reveals this; you only notice when an agent fails at 100K+ for no apparent reason. Detecting it requires probing with questions whose ground-truth answers we control, at exact, verified prompt depths.

**2. Speculative-decode acceptance can quietly collapse.** DSpark/MTP speed comes from the drafter guessing several tokens ahead and the target accepting most of them. Any kernel or sampling-path change can keep the engine fully functional while dropping the accept rate — a "faster" build that is actually net slower, with nothing in the logs flagging it. Measuring it requires diffing the engine's own draft/accepted counters across identical workloads, not eyeballing tok/s once.

Both checks are already **mandated** by `docs/VLLM_PATCH_MANIFEST.md`, but until now they were done ad hoc — hand-built prompts, manual curl, reading metrics by eye. This PR turns each into a script so the mandated gate is actually runnable, repeatable, and CI-friendly.

## What the scripts do

### benchmarks/recall_probe.py — does the model still retrieve at depth?

RULER-style synthetic tasks with known ground truth: single needle, multi-key needle, variable-tracking chain (16 links), common-words extraction. Run against any live OpenAI endpoint:

- **Exact depth control**: when the server exposes `/tokenize` (probed at server root and `/v1`; working URL cached), prompts are corrected *before* generation to land inside `[--min-token-frac, 103%]` of the requested length. Servers without a tokenize endpoint fall back to `usage.prompt_tokens` as the authoritative billed size, with a calibrated filler estimate and one corrective resend. A "32k PASS" therefore means a ~32k prompt was really billed — recorded per row in the JSON report.
- Deterministic scoring at temperature 0; seeded and reproducible (no `PYTHONHASHSEED` dependence); planted vocabulary disjoint from the filler.
- Thinking mode disabled per request by default (`chat_template_kwargs`) so the token budget reaches the answer; `--thinking` restores the server default.
- Client timeouts reported as ERROR with guidance, never silently scored as model failures. Exit 1 on any failure; `--output` writes the JSON report.

Example: `python3 benchmarks/recall_probe.py --base-url http://host:8000/v1 --lengths 8192 32768 131072`

### benchmarks/spec_acceptance.py — did drafting survive my change?

Snapshots the `vllm:spec_decode_*` Prometheus counters, drives a fixed request burst, snapshots again, and reports:

- overall accepted/draft ratio, always alongside raw counter deltas (bonus-token accounting differs between vLLM versions)
- per-position acceptance curve when the build exposes `_per_pos{k}` splits; builds that aggregate into `_per_pos_total` degrade gracefully to the overall ratio
- burst size from `usage.completion_tokens`, not visible content — reasoning-mode servers return null content while generating the full budget
- `/metrics` resolved at the server root likewise; exits 0 with guidance when spec decode is off, exit 2 on transport errors

Run it before/after any patcher or upgrade and compare: same workload, ratio should hold.

## Validation

Live against a TP=2 DeepSeek-V4-Flash host (512K ctx):

- **recall**: ALL PASS, 12/12 across 8k/32k/128k — niah, multikey, vt, cwe (10/10 words at every depth); first-send sizing inside [97%, 103%] of target with zero resends (e.g. 8043 tokens billed for a requested 8192)
- **acceptance**: non-zero completion-token totals; deltas + overall ratio reported correctly (~5 draft proposals per step at K=5)

Offline: `py_compile` clean, full unit suite green, Prometheus parser smoke-tested against mixed labeled/unlabeled samples, task constructors checked for determinism and self-consistency.